### PR TITLE
Changed exception handling + logging instead of printing exceptions; Bot now saves faild and successful refactoring; Added further refactoring checks after the database was reset

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,12 @@
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
 		</dependency>
+		<!-- Sonar-Source-Plugin -->
+		<dependency>
+			<groupId>org.sonarsource.scanner.maven</groupId>
+			<artifactId>sonar-maven-plugin</artifactId>
+			<version>3.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/de/refactoringBot/api/main/ApiGrabber.java
+++ b/src/main/java/de/refactoringBot/api/main/ApiGrabber.java
@@ -63,8 +63,6 @@ public class ApiGrabber {
 			GithubPullRequests githubRequests = githubGrabber.getAllPullRequests(gitConfig);
 			// Translate github object
 			botRequests = githubTranslator.translateRequests(githubRequests, gitConfig);
-			// Check if max amount of requests reached
-			botController.checkAmountOfBotRequests(botRequests, gitConfig);
 			break;
 		}
 		return botRequests;
@@ -114,6 +112,42 @@ public class ApiGrabber {
 			githubGrabber.responseToBotComment(
 					githubTranslator.createReplyComment(comment, gitConfig, newGithubRequest.getHtmlUrl()), gitConfig,
 					request.getRequestNumber());
+			break;
+		}
+	}
+	
+	/**
+	 * Reply to comment if refactoring failed.
+	 * 
+	 * @param request
+	 * @param gitConfig
+	 * @throws Exception
+	 */
+	public void replyToUserForFailedRefactoring(BotPullRequest request, BotPullRequestComment comment, GitConfiguration gitConfig, String errorMessage) throws Exception {
+		// Pick filehoster
+		switch (gitConfig.getRepoService()) {
+		case "github":
+			// Reply to comment
+			githubGrabber.responseToBotComment(
+					githubTranslator.createFailureReply(comment, errorMessage), gitConfig,
+					request.getRequestNumber());
+			break;
+		}
+	}
+	
+	/**
+	 * Check if Branch exists on repository.
+	 * 
+	 * @param request
+	 * @param gitConfig
+	 * @throws Exception
+	 */
+	public void checkBranch(GitConfiguration gitConfig, String branchName) throws Exception {
+		// Pick filehoster
+		switch (gitConfig.getRepoService()) {
+		case "github":
+			// Reply to comment
+			githubGrabber.checkBranch(gitConfig, branchName);
 			break;
 		}
 	}

--- a/src/main/java/de/refactoringBot/api/main/ApiGrabber.java
+++ b/src/main/java/de/refactoringBot/api/main/ApiGrabber.java
@@ -17,7 +17,6 @@ import de.refactoringBot.model.configuration.GitConfiguration;
 import de.refactoringBot.model.githubModels.pullRequest.GithubCreateRequest;
 import de.refactoringBot.model.githubModels.pullRequest.GithubPullRequest;
 import de.refactoringBot.model.githubModels.pullRequest.GithubPullRequests;
-import de.refactoringBot.model.githubModels.pullRequest.GithubUpdateRequest;
 import de.refactoringBot.model.outputModel.botPullRequest.BotPullRequest;
 import de.refactoringBot.model.outputModel.botPullRequest.BotPullRequests;
 import de.refactoringBot.model.outputModel.botPullRequestComment.BotPullRequestComment;
@@ -69,22 +68,19 @@ public class ApiGrabber {
 	}
 
 	/**
-	 * This method updates a pull request of a specific filehoster.
+	 * This method replies to User inside a Pull-Request that belongs to a Bot if
+	 * the refactoring was successful.
 	 * 
 	 * @param request
 	 * @param gitConfig
 	 * @throws Exception
 	 * @throws OperationNotSupportedException
 	 */
-	public void makeUpdateRequest(BotPullRequest request, BotPullRequestComment comment, GitConfiguration gitConfig)
-			throws Exception {
+	public void replyToUserInsideBotRequest(BotPullRequest request, BotPullRequestComment comment,
+			GitConfiguration gitConfig) throws Exception {
 		// Pick filehoster
 		switch (gitConfig.getRepoService()) {
 		case "github":
-			// Create updateRequest
-			GithubUpdateRequest updateRequest = githubTranslator.makeUpdateRequest(request, gitConfig);
-			// Update Request
-			githubGrabber.updatePullRequest(updateRequest, gitConfig, request.getRequestNumber());
 			// Reply to comment
 			githubGrabber.responseToBotComment(githubTranslator.createReplyComment(comment, gitConfig, null), gitConfig,
 					request.getRequestNumber());
@@ -115,7 +111,7 @@ public class ApiGrabber {
 			break;
 		}
 	}
-	
+
 	/**
 	 * Reply to comment if refactoring failed.
 	 * 
@@ -123,18 +119,18 @@ public class ApiGrabber {
 	 * @param gitConfig
 	 * @throws Exception
 	 */
-	public void replyToUserForFailedRefactoring(BotPullRequest request, BotPullRequestComment comment, GitConfiguration gitConfig, String errorMessage) throws Exception {
+	public void replyToUserForFailedRefactoring(BotPullRequest request, BotPullRequestComment comment,
+			GitConfiguration gitConfig, String errorMessage) throws Exception {
 		// Pick filehoster
 		switch (gitConfig.getRepoService()) {
 		case "github":
 			// Reply to comment
-			githubGrabber.responseToBotComment(
-					githubTranslator.createFailureReply(comment, errorMessage), gitConfig,
+			githubGrabber.responseToBotComment(githubTranslator.createFailureReply(comment, errorMessage), gitConfig,
 					request.getRequestNumber());
 			break;
 		}
 	}
-	
+
 	/**
 	 * Check if Branch exists on repository.
 	 * 

--- a/src/main/java/de/refactoringBot/api/sonarQube/SonarQubeDataGrabber.java
+++ b/src/main/java/de/refactoringBot/api/sonarQube/SonarQubeDataGrabber.java
@@ -2,6 +2,8 @@ package de.refactoringBot.api.sonarQube;
 
 import java.net.URI;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -22,6 +24,9 @@ import de.refactoringBot.model.sonarQube.SonarQubeIssues;
 public class SonarQubeDataGrabber {
 
 	private final String USER_AGENT = "Mozilla/5.0";
+
+	// Logger
+	private static final Logger logger = LoggerFactory.getLogger(SonarQubeDataGrabber.class);
 
 	/**
 	 * This method gets all SonarCubeIssues of a Project.
@@ -51,6 +56,7 @@ public class SonarQubeDataGrabber {
 		try {
 			return rest.exchange(sonarQubeURI, HttpMethod.GET, entity, SonarQubeIssues.class).getBody();
 		} catch (RestClientException e) {
+			logger.error(e.getMessage(), e);
 			throw new Exception("Could not access SonarCube API!");
 		}
 	}
@@ -82,6 +88,7 @@ public class SonarQubeDataGrabber {
 		try {
 			rest.exchange(sonarQubeURI, HttpMethod.GET, entity, SonarQubeIssues.class).getBody();
 		} catch (RestClientException e) {
+			logger.error(e.getMessage(), e);
 			throw new Exception("Project with given project key does not exist on SonarQube!");
 		}
 	}

--- a/src/main/java/de/refactoringBot/controller/main/BotController.java
+++ b/src/main/java/de/refactoringBot/controller/main/BotController.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import de.refactoringBot.model.botIssue.BotIssue;
@@ -24,16 +26,18 @@ import de.refactoringBot.model.refactoredIssue.RefactoredIssue;
  */
 @Component
 public class BotController {
+	
+	// Logger
+	private static final Logger logger = LoggerFactory.getLogger(BotController.class);
 
 	/**
-	 * This method checks if the maximal amount of pull requests created by the bot
-	 * is reached.
+	 * This method returns the maximal amount of pull requests created by the bot.
 	 * 
 	 * @param requests
 	 * @param gitConfig
 	 * @throws Exception
 	 */
-	public void checkAmountOfBotRequests(BotPullRequests requests, GitConfiguration gitConfig) throws Exception {
+	public Integer getAmountOfBotRequests(BotPullRequests requests, GitConfiguration gitConfig) {
 
 		// Init counter
 		int counter = 0;
@@ -44,12 +48,8 @@ public class BotController {
 				counter++;
 			}
 		}
-
-		// Check if max amount is reached
-		if (counter >= gitConfig.getMaxAmountRequests()) {
-			throw new Exception("Maximal amount of requests reached." + "(Maximum = " + gitConfig.getMaxAmountRequests()
-					+ "; Currently = " + counter + " bot requests are open)");
-		}
+		
+		return counter;
 	}
 
 	/**
@@ -78,6 +78,12 @@ public class BotController {
 		refactoredIssue.setAnalysisService(gitConfig.getAnalysisService());
 		refactoredIssue.setAnalysisServiceProjectKey(gitConfig.getAnalysisServiceProjectKey());
 		refactoredIssue.setRefactoringOperation(issue.getRefactoringOperation());
+		
+		if (issue.getCommitMessage() != null && issue.getErrorMessage() == null) {
+			refactoredIssue.setStatus("SUCCESSFUL");
+		} else  {
+			refactoredIssue.setStatus("FAILED");
+		}
 
 		return refactoredIssue;
 	}
@@ -141,6 +147,7 @@ public class BotController {
 		}
 		
 		// If no src-folder found
+		logger.error("No src-folder found inside this java-project!");
 		throw new Exception("No src-folder found inside this java-project!");
 	}
 }

--- a/src/main/java/de/refactoringBot/controller/main/GitController.java
+++ b/src/main/java/de/refactoringBot/controller/main/GitController.java
@@ -6,6 +6,7 @@ import org.eclipse.jgit.api.CreateBranchCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.RemoteAddCommand;
 import org.eclipse.jgit.api.errors.RefAlreadyExistsException;
+import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.api.errors.TransportException;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.transport.URIish;
@@ -152,7 +153,7 @@ public class GitController {
 	 * @param id
 	 * @throws Exception
 	 */
-	public void createBranch(GitConfiguration gitConfig, String branchName, String newBranch) throws Exception {
+	public void createBranch(GitConfiguration gitConfig, String branchName, String newBranch, String origin) throws Exception {
 		Git git = null;
 		try {
 			// Open git folder
@@ -161,7 +162,7 @@ public class GitController {
 			@SuppressWarnings("unused")
 			Ref ref = git.checkout().setCreateBranch(true).setName(newBranch)
 					.setUpstreamMode(CreateBranchCommand.SetupUpstreamMode.TRACK)
-					.setStartPoint("upstream/" + branchName).call();
+					.setStartPoint(origin + "/" + branchName).call();
 			// Pull data
 			git.pull();
 			git.close();
@@ -201,6 +202,9 @@ public class GitController {
 			@SuppressWarnings("unused")
 			Ref ref = git.checkout().setName(branchName).call();
 			git.close();
+			
+		} catch (RefNotFoundException r) {
+			createBranch(gitConfig, branchName, branchName, "origin");
 		} catch (Exception e) {
 			// Close git if possible
 			if (git != null) {

--- a/src/main/java/de/refactoringBot/controller/main/GitController.java
+++ b/src/main/java/de/refactoringBot/controller/main/GitController.java
@@ -29,7 +29,7 @@ public class GitController {
 
 	@Autowired
 	BotConfiguration botConfig;
-	
+
 	// Logger
 	private static final Logger logger = LoggerFactory.getLogger(GitController.class);
 
@@ -85,7 +85,10 @@ public class GitController {
 			git.fetch().setRemote("upstream").call();
 			git.close();
 		} catch (Exception e) {
-			git.close();
+			// Close git if possible
+			if (git != null) {
+				git.close();
+			}
 			logger.error(e.getMessage(), e);
 			throw new Exception("Could not fetch data from 'upstream'!");
 		}
@@ -106,7 +109,10 @@ public class GitController {
 			git.stashApply().call();
 			git.close();
 		} catch (Exception e) {
-			git.close();
+			// Close git if possible
+			if (git != null) {
+				git.close();
+			}
 			logger.error(e.getMessage(), e);
 			throw new Exception("Faild to stash changes!");
 		}
@@ -127,7 +133,11 @@ public class GitController {
 					.call();
 			git.close();
 		} catch (Exception e) {
-			git.close();
+			// Close git if possible
+			if (git != null) {
+				git.close();
+			}
+
 			logger.error(e.getMessage(), e);
 			throw new Exception("Faild to clone " + "'" + gitConfig.getForkGitLink() + "' successfully!");
 		}
@@ -157,11 +167,19 @@ public class GitController {
 			git.close();
 			// If branch already exists
 		} catch (RefAlreadyExistsException r) {
-			git.close();
+			// Close git if possible
+			if (git != null) {
+				git.close();
+			}
 			logger.error(r.getMessage(), r);
-			throw new Exception("Issue was already refactored in the past! The bot database might have been resetted but not the fork itself.");
+			throw new Exception(
+					"Issue was already refactored in the past! The bot database might have been resetted but not the fork itself.");
 		} catch (Exception e) {
-			git.close();
+			// Close git if possible
+			if (git != null) {
+				git.close();
+			}
+
 			logger.error(e.getMessage(), e);
 			throw new Exception("Branch with the name " + "'" + newBranch + "' could not be created!");
 		}
@@ -184,7 +202,11 @@ public class GitController {
 			Ref ref = git.checkout().setName(branchName).call();
 			git.close();
 		} catch (Exception e) {
-			git.close();
+			// Close git if possible
+			if (git != null) {
+				git.close();
+			}
+
 			logger.error(e.getMessage(), e);
 			throw new Exception("Could not switch to the branch with the name " + "'" + branchName + "'!");
 		}
@@ -210,12 +232,20 @@ public class GitController {
 							new UsernamePasswordCredentialsProvider(gitConfig.getBotName(), gitConfig.getBotPassword()))
 					.call();
 			git.close();
-		} catch (TransportException t) { 
-			git.close();
+		} catch (TransportException t) {
+			// Close git if possible
+			if (git != null) {
+				git.close();
+			}
+
 			logger.error(t.getMessage(), t);
 			throw new Exception("Wrong bot password!");
 		} catch (Exception e) {
-			git.close();
+			// Close git if possible
+			if (git != null) {
+				git.close();
+			}
+
 			logger.error(e.getMessage(), e);
 			throw new Exception("Could not successfully perform 'git push'!");
 		}

--- a/src/main/java/de/refactoringBot/controller/main/GitController.java
+++ b/src/main/java/de/refactoringBot/controller/main/GitController.java
@@ -153,7 +153,8 @@ public class GitController {
 	 * @param id
 	 * @throws Exception
 	 */
-	public void createBranch(GitConfiguration gitConfig, String branchName, String newBranch, String origin) throws Exception {
+	public void createBranch(GitConfiguration gitConfig, String branchName, String newBranch, String origin)
+			throws Exception {
 		Git git = null;
 		try {
 			// Open git folder
@@ -202,8 +203,13 @@ public class GitController {
 			@SuppressWarnings("unused")
 			Ref ref = git.checkout().setName(branchName).call();
 			git.close();
-			
+			// If branch does not exist localy anymore
 		} catch (RefNotFoundException r) {
+			// Close git if possible
+			if (git != null) {
+				git.close();
+			}
+			// Recreate branch with current branch data from remote origin
 			createBranch(gitConfig, branchName, branchName, "origin");
 		} catch (Exception e) {
 			// Close git if possible

--- a/src/main/java/de/refactoringBot/controller/main/GitController.java
+++ b/src/main/java/de/refactoringBot/controller/main/GitController.java
@@ -193,7 +193,6 @@ public class GitController {
 	 * @param branchName
 	 * @throws Exception
 	 */
-
 	public void switchBranch(GitConfiguration gitConfig, String branchName) throws Exception {
 		Git git = null;
 		try {

--- a/src/main/java/de/refactoringBot/controller/main/GitController.java
+++ b/src/main/java/de/refactoringBot/controller/main/GitController.java
@@ -10,6 +10,8 @@ import org.eclipse.jgit.api.errors.TransportException;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.transport.URIish;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -27,6 +29,9 @@ public class GitController {
 
 	@Autowired
 	BotConfiguration botConfig;
+	
+	// Logger
+	private static final Logger logger = LoggerFactory.getLogger(GitController.class);
 
 	/**
 	 * This method initialises the workspace.
@@ -60,7 +65,7 @@ public class GitController {
 			git.close();
 		} catch (Exception e) {
 			git.close();
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			throw new Exception("Could not add as remote " + "'" + gitConfig.getRepoGitLink() + "' successfully!");
 		}
 	}
@@ -81,7 +86,7 @@ public class GitController {
 			git.close();
 		} catch (Exception e) {
 			git.close();
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			throw new Exception("Could not fetch data from 'upstream'!");
 		}
 	}
@@ -102,7 +107,7 @@ public class GitController {
 			git.close();
 		} catch (Exception e) {
 			git.close();
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			throw new Exception("Faild to stash changes!");
 		}
 	}
@@ -123,6 +128,7 @@ public class GitController {
 			git.close();
 		} catch (Exception e) {
 			git.close();
+			logger.error(e.getMessage(), e);
 			throw new Exception("Faild to clone " + "'" + gitConfig.getForkGitLink() + "' successfully!");
 		}
 	}
@@ -152,11 +158,11 @@ public class GitController {
 			// If branch already exists
 		} catch (RefAlreadyExistsException r) {
 			git.close();
-			// Switch to branch
-			switchBranch(gitConfig, newBranch);
+			logger.error(r.getMessage(), r);
+			throw new Exception("Issue was already refactored in the past! The bot database might have been resetted but not the fork itself.");
 		} catch (Exception e) {
 			git.close();
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			throw new Exception("Branch with the name " + "'" + newBranch + "' could not be created!");
 		}
 	}
@@ -179,7 +185,7 @@ public class GitController {
 			git.close();
 		} catch (Exception e) {
 			git.close();
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			throw new Exception("Could not switch to the branch with the name " + "'" + branchName + "'!");
 		}
 	}
@@ -206,9 +212,11 @@ public class GitController {
 			git.close();
 		} catch (TransportException t) { 
 			git.close();
+			logger.error(t.getMessage(), t);
 			throw new Exception("Wrong bot password!");
 		} catch (Exception e) {
 			git.close();
+			logger.error(e.getMessage(), e);
 			throw new Exception("Could not successfully perform 'git push'!");
 		}
 	}

--- a/src/main/java/de/refactoringBot/controller/main/GitController.java
+++ b/src/main/java/de/refactoringBot/controller/main/GitController.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 
 import de.refactoringBot.configuration.BotConfiguration;
 import de.refactoringBot.model.configuration.GitConfiguration;
+import de.refactoringBot.model.exceptions.BotRefactoringException;
 
 /**
  * This class uses git programmicaly with JGIT.
@@ -174,7 +175,7 @@ public class GitController {
 				git.close();
 			}
 			logger.error(r.getMessage(), r);
-			throw new Exception(
+			throw new BotRefactoringException(
 					"Issue was already refactored in the past! The bot database might have been resetted but not the fork itself.");
 		} catch (Exception e) {
 			// Close git if possible

--- a/src/main/java/de/refactoringBot/controller/main/GitController.java
+++ b/src/main/java/de/refactoringBot/controller/main/GitController.java
@@ -181,7 +181,6 @@ public class GitController {
 			if (git != null) {
 				git.close();
 			}
-
 			logger.error(e.getMessage(), e);
 			throw new Exception("Branch with the name " + "'" + newBranch + "' could not be created!");
 		}
@@ -215,7 +214,6 @@ public class GitController {
 			if (git != null) {
 				git.close();
 			}
-
 			logger.error(e.getMessage(), e);
 			throw new Exception("Could not switch to the branch with the name " + "'" + branchName + "'!");
 		}
@@ -246,7 +244,6 @@ public class GitController {
 			if (git != null) {
 				git.close();
 			}
-
 			logger.error(t.getMessage(), t);
 			throw new Exception("Wrong bot password!");
 		} catch (Exception e) {
@@ -254,7 +251,6 @@ public class GitController {
 			if (git != null) {
 				git.close();
 			}
-
 			logger.error(e.getMessage(), e);
 			throw new Exception("Could not successfully perform 'git push'!");
 		}

--- a/src/main/java/de/refactoringBot/controller/main/GrammarController.java
+++ b/src/main/java/de/refactoringBot/controller/main/GrammarController.java
@@ -5,6 +5,8 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.ConsoleErrorListener;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -27,6 +29,9 @@ public class GrammarController {
 	
 	@Autowired
 	RefactoringOperations operations;
+	
+	// Logger
+	private static final Logger logger = LoggerFactory.getLogger(GrammarController.class);
 
 	/**
 	 * This method checks if a comment has a valid bot grammar and returns if the
@@ -127,7 +132,7 @@ public class GrammarController {
 			}
 			return issue;
 		} catch (Exception e) {
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			throw new Exception("Could not create a BotIssue from the comment '" + comment.getCommentBody() + "'!");
 		}
 	}

--- a/src/main/java/de/refactoringBot/controller/sonarQube/SonarQubeObjectTranslator.java
+++ b/src/main/java/de/refactoringBot/controller/sonarQube/SonarQubeObjectTranslator.java
@@ -63,17 +63,18 @@ public class SonarQubeObjectTranslator {
 			switch (issue.getRule()) {
 			case "squid:S1161":
 				botIssue.setRefactoringOperation(operations.ADD_OVERRIDE_ANNOTATION);
+				// Add bot issue to list
+				botIssues.add(botIssue);
 				break;
 			case "squid:ModifiersOrderCheck":
 				botIssue.setRefactoringOperation(operations.REORDER_MODIFIER);
+				// Add bot issue to list
+				botIssues.add(botIssue);
 				break;
 			default:
 				botIssue.setRefactoringOperation(operations.UNKNOWN);
 				break;
 			}
-
-			// Add bot issue to list
-			botIssues.add(botIssue);
 		}
 
 		return botIssues;

--- a/src/main/java/de/refactoringBot/model/botIssue/BotIssue.java
+++ b/src/main/java/de/refactoringBot/model/botIssue/BotIssue.java
@@ -7,6 +7,8 @@ public class BotIssue {
 	private Integer line;
 	private String commentServiceID;
 	private String refactorString;
+	private String errorMessage;
+	private String commitMessage;
 	
 	public String getRefactoringOperation() {
 		return refactoringOperation;
@@ -46,6 +48,22 @@ public class BotIssue {
 
 	public void setRefactorString(String refactorString) {
 		this.refactorString = refactorString;
+	}
+
+	public String getErrorMessage() {
+		return errorMessage;
+	}
+
+	public void setErrorMessage(String errorMessage) {
+		this.errorMessage = errorMessage;
+	}
+
+	public String getCommitMessage() {
+		return commitMessage;
+	}
+
+	public void setCommitMessage(String commitMessage) {
+		this.commitMessage = commitMessage;
 	}
 	
 }

--- a/src/main/java/de/refactoringBot/model/exceptions/BotRefactoringException.java
+++ b/src/main/java/de/refactoringBot/model/exceptions/BotRefactoringException.java
@@ -1,0 +1,21 @@
+package de.refactoringBot.model.exceptions;
+
+public class BotRefactoringException extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	public BotRefactoringException() {
+	}
+
+	public BotRefactoringException(String message) {
+		super(message);
+	}
+
+	public BotRefactoringException(Throwable cause) {
+		super(cause);
+	}
+
+	public BotRefactoringException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/main/java/de/refactoringBot/model/refactoredIssue/RefactoredIssue.java
+++ b/src/main/java/de/refactoringBot/model/refactoredIssue/RefactoredIssue.java
@@ -22,6 +22,7 @@ public class RefactoredIssue {
 	private String analysisService;
 	private String analysisServiceProjectKey;
 	private String refactoringOperation;
+	private String status;
 	
 	public Long getIssueId() {
 		return issueId;
@@ -89,6 +90,14 @@ public class RefactoredIssue {
 
 	public void setAnalysisServiceProjectKey(String analysisServiceProjectKey) {
 		this.analysisServiceProjectKey = analysisServiceProjectKey;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
 	}
 	
 }

--- a/src/main/java/de/refactoringBot/refactoring/RefactoringImpl.java
+++ b/src/main/java/de/refactoringBot/refactoring/RefactoringImpl.java
@@ -1,8 +1,5 @@
 package de.refactoringBot.refactoring;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-
 import de.refactoringBot.model.botIssue.BotIssue;
 import de.refactoringBot.model.configuration.GitConfiguration;
 
@@ -22,8 +19,7 @@ public interface RefactoringImpl {
 	 * @param issue
 	 * @param gitConfig
 	 * @return commitMessage
-	 * @throws FileNotFoundException 
-	 * @throws IOException 
+	 * @throws Exception 
 	 */
-	public String performRefactoring(BotIssue issue, GitConfiguration gitConfig) throws FileNotFoundException, IOException;
+	public String performRefactoring(BotIssue issue, GitConfiguration gitConfig) throws Exception;
 }

--- a/src/main/java/de/refactoringBot/refactoring/supportedRefactorings/AddOverrideAnnotation.java
+++ b/src/main/java/de/refactoringBot/refactoring/supportedRefactorings/AddOverrideAnnotation.java
@@ -1,7 +1,6 @@
 package de.refactoringBot.refactoring.supportedRefactorings;
 
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 import java.util.List;
 
@@ -14,6 +13,7 @@ import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinte
 
 import de.refactoringBot.model.botIssue.BotIssue;
 import de.refactoringBot.model.configuration.GitConfiguration;
+import de.refactoringBot.model.exceptions.BotRefactoringException;
 import de.refactoringBot.refactoring.RefactoringImpl;
 
 /**
@@ -30,10 +30,10 @@ public class AddOverrideAnnotation implements RefactoringImpl {
 	 * @param issue
 	 * @param gitConfig
 	 * @return commitMessage
-	 * @throws FileNotFoundException
+	 * @throws Exception 
 	 */
 	@Override
-	public String performRefactoring(BotIssue issue, GitConfiguration gitConfig) throws FileNotFoundException {
+	public String performRefactoring(BotIssue issue, GitConfiguration gitConfig) throws Exception {
 
 		// Prepare data
 		String path = issue.getFilePath();
@@ -58,7 +58,7 @@ public class AddOverrideAnnotation implements RefactoringImpl {
 
 		// If method not found
 		if (methodName == null) {
-			return null;
+			throw new BotRefactoringException("Could not find method at specified line! Automated refactoring failed.");
 		}
 
 		// Save changes to file

--- a/src/main/java/de/refactoringBot/refactoring/supportedRefactorings/RemoveMethodParameter.java
+++ b/src/main/java/de/refactoringBot/refactoring/supportedRefactorings/RemoveMethodParameter.java
@@ -3,7 +3,6 @@ package de.refactoringBot.refactoring.supportedRefactorings;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,10 +48,10 @@ public class RemoveMethodParameter implements RefactoringImpl {
 	 * @param issue
 	 * @param gitConfig
 	 * @return commitMessage
-	 * @throws IOException
+	 * @throws Exception 
 	 */
 	@Override
-	public String performRefactoring(BotIssue issue, GitConfiguration gitConfig) throws IOException {
+	public String performRefactoring(BotIssue issue, GitConfiguration gitConfig) throws Exception {
 
 		// Init Refactorings
 		ParserRefactoringCollection allRefactorings = new ParserRefactoringCollection();
@@ -123,7 +122,7 @@ public class RemoveMethodParameter implements RefactoringImpl {
 
 		// If refactor-method not found
 		if (methodToRefactor == null) {
-			return null;
+			throw new Exception("Could not find specified method! Automated refactoring failed.");
 		}
 
 		// Add class to the TO-DO list
@@ -160,7 +159,7 @@ public class RemoveMethodParameter implements RefactoringImpl {
 		}
 
 		removeParameter(allRefactorings, allJavaFiles, issue.getRefactorString(), paramPosition);
-
+		
 		return "Removed method parameter '" + issue.getRefactorString() + "' of method '" + oldMethodName + "'";
 	}
 

--- a/src/main/java/de/refactoringBot/rest/ConfigurationController.java
+++ b/src/main/java/de/refactoringBot/rest/ConfigurationController.java
@@ -120,7 +120,7 @@ public class ConfigurationController {
 			// Fetch target-Repository-Data and check bot password
 			gitController.fetchRemote(savedConfig);
 			String newBranch = "testCredentialsFor_" + savedConfig.getBotName();
-			gitController.createBranch(savedConfig, "master", newBranch);
+			gitController.createBranch(savedConfig, "master", newBranch, "upstream");
 			gitController.pushChanges(savedConfig, "Test bot password");
 
 			return new ResponseEntity<GitConfiguration>(config, HttpStatus.CREATED);

--- a/src/main/java/de/refactoringBot/rest/ConfigurationController.java
+++ b/src/main/java/de/refactoringBot/rest/ConfigurationController.java
@@ -63,7 +63,7 @@ public class ConfigurationController {
 	@ApiOperation(value = "Create Git-Konfiguration")
 	public ResponseEntity<?> add(
 			@RequestParam(value = "repoService", required = true, defaultValue = "Github") String repoService,
-			@RequestParam(value = "repoName", required = true, defaultValue = "RefactoringTest") String repoName,
+			@RequestParam(value = "repoName", required = true, defaultValue = "Bot-Playground") String repoName,
 			@RequestParam(value = "ownerName", required = true, defaultValue = "Refactoring-Bot") String repoOwner,
 			@RequestParam(value = "botUsername", required = true) String botUsername,
 			@RequestParam(value = "botPassword", required = true) String botPassword,

--- a/src/main/java/de/refactoringBot/rest/ConfigurationController.java
+++ b/src/main/java/de/refactoringBot/rest/ConfigurationController.java
@@ -106,8 +106,10 @@ public class ConfigurationController {
 			gitController.initLocalWorkspace(savedConfig);
 
 			// Add repo path and src-folder path to config
-			savedConfig.setRepoFolder(Paths.get(botConfig.getBotRefactoringDirectory() + savedConfig.getConfigurationId()).toString());
-			savedConfig.setSrcFolder(botController.findSrcFolder(botConfig.getBotRefactoringDirectory() + savedConfig.getConfigurationId()));
+			savedConfig.setRepoFolder(
+					Paths.get(botConfig.getBotRefactoringDirectory() + savedConfig.getConfigurationId()).toString());
+			savedConfig.setSrcFolder(botController
+					.findSrcFolder(botConfig.getBotRefactoringDirectory() + savedConfig.getConfigurationId()));
 			repo.save(savedConfig);
 
 			// Fetch target-Repository-Data and check bot password
@@ -153,7 +155,15 @@ public class ConfigurationController {
 	public ResponseEntity<?> deleteConfig(
 			@RequestParam(value = "configurationId", required = true) Long configurationId) {
 		// Check if configuration exists
-		Optional<GitConfiguration> existsConfig = repo.getByID(configurationId);
+		Optional<GitConfiguration> existsConfig;
+		try {
+			// Try to get the Git-Configuration with the given ID
+			existsConfig = repo.getByID(configurationId);
+		} catch (Exception e) {
+			// Print exception and abort if database error occurs
+			e.printStackTrace();
+			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
+		}
 		String userFeedback = "";
 		// If it does
 		if (existsConfig.isPresent()) {
@@ -196,7 +206,14 @@ public class ConfigurationController {
 	@RequestMapping(value = "/getAllConfigs", method = RequestMethod.GET, produces = "application/json")
 	@ApiOperation(value = "Get all Git-Configurations")
 	public ResponseEntity<?> getAllConfigs() {
-		Iterable<GitConfiguration> allConfigs = repo.findAll();
+		Iterable<GitConfiguration> allConfigs;
+		try {
+			allConfigs = repo.findAll();
+		} catch (Exception e) {
+			// Print exception and abort if database error occurs
+			e.printStackTrace();
+			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
+		}
 		return new ResponseEntity<Iterable<GitConfiguration>>(allConfigs, HttpStatus.OK);
 	}
 }

--- a/src/main/java/de/refactoringBot/rest/ConfigurationController.java
+++ b/src/main/java/de/refactoringBot/rest/ConfigurationController.java
@@ -5,6 +5,8 @@ import java.nio.file.Paths;
 import java.util.Optional;
 
 import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -45,6 +47,9 @@ public class ConfigurationController {
 	GitController gitController;
 	@Autowired
 	BotController botController;
+	
+	// Logger
+    private static final Logger logger = LoggerFactory.getLogger(RefactoringController.class);
 
 	/**
 	 * This method creates an git configuration with the user inputs.
@@ -87,7 +92,7 @@ public class ConfigurationController {
 				savedConfig = repo.save(config);
 			} catch (Exception e) {
 				// Print exception and abort if database error occurs
-				e.printStackTrace();
+				logger.error(e.getMessage(), e);
 				return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
 			}
 
@@ -134,10 +139,10 @@ public class ConfigurationController {
 					grabber.deleteRepository(savedConfig);
 				}
 			} catch (Exception t) {
-				t.printStackTrace();
+				logger.error(t.getMessage(), t);
 			}
 
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			return new ResponseEntity<String>(e.getMessage(), HttpStatus.BAD_REQUEST);
 		}
 	}
@@ -161,7 +166,7 @@ public class ConfigurationController {
 			existsConfig = repo.getByID(configurationId);
 		} catch (Exception e) {
 			// Print exception and abort if database error occurs
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 		String userFeedback = "";
@@ -172,13 +177,14 @@ public class ConfigurationController {
 				repo.delete(existsConfig.get());
 				userFeedback = userFeedback.concat("Configuration deleted from database!");
 			} catch (Exception e) {
-				e.printStackTrace();
+				logger.error(e.getMessage(), e);
 				return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
 			}
 			// Delete repository from the filehoster bot account
 			try {
 				grabber.deleteRepository(existsConfig.get());
 			} catch (Exception e) {
+				logger.error(e.getMessage(), e);
 				userFeedback = userFeedback
 						.concat(" Could not delete repository on " + existsConfig.get().getRepoService() + "!");
 			}
@@ -188,6 +194,7 @@ public class ConfigurationController {
 						botConfig.getBotRefactoringDirectory() + existsConfig.get().getConfigurationId());
 				FileUtils.deleteDirectory(forkFolder);
 			} catch (Exception e) {
+				logger.error(e.getMessage(), e);
 				userFeedback = userFeedback.concat(" Could not delete local folder '"
 						+ existsConfig.get().getConfigurationId() + "' of the configuration!");
 			}
@@ -211,7 +218,7 @@ public class ConfigurationController {
 			allConfigs = repo.findAll();
 		} catch (Exception e) {
 			// Print exception and abort if database error occurs
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 		return new ResponseEntity<Iterable<GitConfiguration>>(allConfigs, HttpStatus.OK);

--- a/src/main/java/de/refactoringBot/rest/ConfigurationController.java
+++ b/src/main/java/de/refactoringBot/rest/ConfigurationController.java
@@ -10,8 +10,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -59,7 +61,7 @@ public class ConfigurationController {
 	 * @param repoService
 	 * @return
 	 */
-	@RequestMapping(value = "/createConfig", method = RequestMethod.POST, produces = "application/json")
+	@PostMapping(value = "/createConfig", produces = "application/json")
 	@ApiOperation(value = "Create Git-Konfiguration")
 	public ResponseEntity<?> add(
 			@RequestParam(value = "repoService", required = true, defaultValue = "Github") String repoService,
@@ -155,7 +157,7 @@ public class ConfigurationController {
 	 * @param repoService
 	 * @return {feedbackString}
 	 */
-	@RequestMapping(value = "/deleteConfig", method = RequestMethod.DELETE, produces = "application/json")
+	@DeleteMapping(value = "/deleteConfig", produces = "application/json")
 	@ApiOperation(value = "Delete Git-Konfiguration")
 	public ResponseEntity<?> deleteConfig(
 			@RequestParam(value = "configurationId", required = true) Long configurationId) {
@@ -210,7 +212,7 @@ public class ConfigurationController {
 	 * 
 	 * @return allConfigs
 	 */
-	@RequestMapping(value = "/getAllConfigs", method = RequestMethod.GET, produces = "application/json")
+	@GetMapping(value = "/getAllConfigs", produces = "application/json")
 	@ApiOperation(value = "Get all Git-Configurations")
 	public ResponseEntity<?> getAllConfigs() {
 		Iterable<GitConfiguration> allConfigs;

--- a/src/main/java/de/refactoringBot/rest/RefactoredIssuesController.java
+++ b/src/main/java/de/refactoringBot/rest/RefactoredIssuesController.java
@@ -5,8 +5,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,7 +36,7 @@ public class RefactoredIssuesController {
 	 * 
 	 * @return allIssues
 	 */
-	@RequestMapping(value = "/getAllIssues", method = RequestMethod.GET, produces = "application/json")
+	@GetMapping(value = "/getAllIssues", produces = "application/json")
 	@ApiOperation(value = "Get all refactored issues.")
 	public ResponseEntity<?> getAllIssues() {
 		Iterable<RefactoredIssue> allIssues;
@@ -54,7 +55,7 @@ public class RefactoredIssuesController {
 	 * 
 	 * @return allIssues
 	 */
-	@RequestMapping(value = "/getAllServiceIssues", method = RequestMethod.GET, produces = "application/json")
+	@GetMapping(value = "/getAllServiceIssues", produces = "application/json")
 	@ApiOperation(value = "Get all refactored issues from a specific filehoster.")
 	public ResponseEntity<?> getAllServiceIssues(
 			@RequestParam(value = "repoService", required = true, defaultValue = "github") String repoService) {
@@ -75,7 +76,7 @@ public class RefactoredIssuesController {
 	 * 
 	 * @return allIssues
 	 */
-	@RequestMapping(value = "/getAllUserIssues", method = RequestMethod.GET, produces = "application/json")
+	@GetMapping(value = "/getAllUserIssues", produces = "application/json")
 	@ApiOperation(value = "Get all refactored issues of a specific user from a specific filehoster.")
 	public ResponseEntity<?> getAllUserIssues(
 			@RequestParam(value = "repoService", required = true, defaultValue = "github") String repoService,
@@ -96,7 +97,7 @@ public class RefactoredIssuesController {
 	 * 
 	 * @return feedback
 	 */
-	@RequestMapping(value = "/deleteAllIssues", method = RequestMethod.DELETE, produces = "application/json")
+	@DeleteMapping(value = "/deleteAllIssues", produces = "application/json")
 	@ApiOperation(value = "This method deletes all refactored issues from the database (for testing purposes).")
 	public ResponseEntity<?> deleteAllRefactoredIssues() {
 		try {

--- a/src/main/java/de/refactoringBot/rest/RefactoredIssuesController.java
+++ b/src/main/java/de/refactoringBot/rest/RefactoredIssuesController.java
@@ -33,7 +33,14 @@ public class RefactoredIssuesController {
 	@RequestMapping(value = "/getAllIssues", method = RequestMethod.GET, produces = "application/json")
 	@ApiOperation(value = "Get all refactored issues.")
 	public ResponseEntity<?> getAllIssues() {
-		Iterable<RefactoredIssue> allIssues = repo.findAll();
+		Iterable<RefactoredIssue> allIssues;
+		try {
+			allIssues = repo.findAll();
+		} catch (Exception e) {
+			// Print exception and abort if database error occurs
+			e.printStackTrace();
+			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
+		}
 		return new ResponseEntity<Iterable<RefactoredIssue>>(allIssues, HttpStatus.OK);
 	}
 
@@ -46,7 +53,14 @@ public class RefactoredIssuesController {
 	@ApiOperation(value = "Get all refactored issues from a specific filehoster.")
 	public ResponseEntity<?> getAllServiceIssues(
 			@RequestParam(value = "repoService", required = true, defaultValue = "github") String repoService) {
-		Iterable<RefactoredIssue> allIssues = repo.getAllServiceRefactorings(repoService);
+		Iterable<RefactoredIssue> allIssues;
+		try {
+			allIssues = repo.getAllServiceRefactorings(repoService);
+		} catch (Exception e) {
+			// Print exception and abort if database error occurs
+			e.printStackTrace();
+			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
+		}
 		return new ResponseEntity<Iterable<RefactoredIssue>>(allIssues, HttpStatus.OK);
 	}
 
@@ -61,7 +75,14 @@ public class RefactoredIssuesController {
 	public ResponseEntity<?> getAllUserIssues(
 			@RequestParam(value = "repoService", required = true, defaultValue = "github") String repoService,
 			@RequestParam(value = "ownerName", required = true, defaultValue = "LHommeDeBat") String repoOwner) {
-		Iterable<RefactoredIssue> allIssues = repo.getAllUserIssues(repoService, repoOwner);
+		Iterable<RefactoredIssue> allIssues;
+		try {
+			allIssues = repo.getAllUserIssues(repoService, repoOwner);
+		} catch (Exception e) {
+			// Print exception and abort if database error occurs
+			e.printStackTrace();
+			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
+		}
 		return new ResponseEntity<Iterable<RefactoredIssue>>(allIssues, HttpStatus.OK);
 	}
 
@@ -73,7 +94,13 @@ public class RefactoredIssuesController {
 	@RequestMapping(value = "/deleteAllIssues", method = RequestMethod.DELETE, produces = "application/json")
 	@ApiOperation(value = "This method deletes all refactored issues from the database (for testing purposes).")
 	public ResponseEntity<?> deleteAllRefactoredIssues() {
-		repo.deleteAll();
+		try {
+			repo.deleteAll();
+		} catch (Exception e) {
+			// Print exception and abort if database error occurs
+			e.printStackTrace();
+			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
+		}
 		return new ResponseEntity<String>("All refactored issues deleted!", HttpStatus.OK);
 	}
 }

--- a/src/main/java/de/refactoringBot/rest/RefactoredIssuesController.java
+++ b/src/main/java/de/refactoringBot/rest/RefactoredIssuesController.java
@@ -1,5 +1,7 @@
 package de.refactoringBot.rest;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +26,9 @@ public class RefactoredIssuesController {
 
 	@Autowired
 	RefactoredIssueRepository repo;
+	
+	// Logger
+    private static final Logger logger = LoggerFactory.getLogger(RefactoredIssuesController.class);
 
 	/**
 	 * This method returns all refactored issues from the database.
@@ -38,7 +43,7 @@ public class RefactoredIssuesController {
 			allIssues = repo.findAll();
 		} catch (Exception e) {
 			// Print exception and abort if database error occurs
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 		return new ResponseEntity<Iterable<RefactoredIssue>>(allIssues, HttpStatus.OK);
@@ -58,7 +63,7 @@ public class RefactoredIssuesController {
 			allIssues = repo.getAllServiceRefactorings(repoService);
 		} catch (Exception e) {
 			// Print exception and abort if database error occurs
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 		return new ResponseEntity<Iterable<RefactoredIssue>>(allIssues, HttpStatus.OK);
@@ -80,7 +85,7 @@ public class RefactoredIssuesController {
 			allIssues = repo.getAllUserIssues(repoService, repoOwner);
 		} catch (Exception e) {
 			// Print exception and abort if database error occurs
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 		return new ResponseEntity<Iterable<RefactoredIssue>>(allIssues, HttpStatus.OK);
@@ -98,7 +103,7 @@ public class RefactoredIssuesController {
 			repo.deleteAll();
 		} catch (Exception e) {
 			// Print exception and abort if database error occurs
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 		return new ResponseEntity<String>("All refactored issues deleted!", HttpStatus.OK);

--- a/src/main/java/de/refactoringBot/rest/RefactoringController.java
+++ b/src/main/java/de/refactoringBot/rest/RefactoringController.java
@@ -78,8 +78,15 @@ public class RefactoringController {
 		// Create empty list of refactored Issues
 		List<RefactoredIssue> allRefactoredIssues = new ArrayList<RefactoredIssue>();
 
-		// Try to get the Git-Configuration with the given ID
-		Optional<GitConfiguration> gitConfig = configRepo.getByID(configID);
+		Optional<GitConfiguration> gitConfig;
+		try {
+			// Try to get the Git-Configuration with the given ID
+			gitConfig = configRepo.getByID(configID);
+		} catch (Exception e) {
+			// Print exception and abort if database error occurs
+			e.printStackTrace();
+			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
+		}
 		// If Configuration does not exist
 		if (!gitConfig.isPresent()) {
 			return new ResponseEntity<String>("Configuration with given ID does not exist!", HttpStatus.NOT_FOUND);
@@ -187,8 +194,15 @@ public class RefactoringController {
 		// Create empty list of refactored Issues
 		List<RefactoredIssue> allRefactoredIssues = new ArrayList<RefactoredIssue>();
 
-		// Try to get the Git-Configuration with the given ID
-		Optional<GitConfiguration> gitConfig = configRepo.getByID(configID);
+		Optional<GitConfiguration> gitConfig;
+		try {
+			// Try to get the Git-Configuration with the given ID
+			gitConfig = configRepo.getByID(configID);
+		} catch (Exception e) {
+			// Print exception and abort if database error occurs
+			e.printStackTrace();
+			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
+		}
 		// If configuration does not exist
 		if (!gitConfig.isPresent()) {
 			return new ResponseEntity<String>("Configuration with the given ID does not exist!", HttpStatus.NOT_FOUND);

--- a/src/main/java/de/refactoringBot/rest/RefactoringController.java
+++ b/src/main/java/de/refactoringBot/rest/RefactoringController.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +24,7 @@ import de.refactoringBot.controller.sonarQube.SonarQubeObjectTranslator;
 import de.refactoringBot.model.botIssue.BotIssue;
 import de.refactoringBot.model.configuration.ConfigurationRepository;
 import de.refactoringBot.model.configuration.GitConfiguration;
+import de.refactoringBot.model.exceptions.BotRefactoringException;
 import de.refactoringBot.model.outputModel.botPullRequest.BotPullRequest;
 import de.refactoringBot.model.outputModel.botPullRequest.BotPullRequests;
 import de.refactoringBot.model.outputModel.botPullRequestComment.BotPullRequestComment;
@@ -63,6 +66,9 @@ public class RefactoringController {
 	RefactoringPicker refactoring;
 	@Autowired
 	SonarQubeObjectTranslator sonarTranslator;
+	
+	// Logger
+    private static final Logger logger = LoggerFactory.getLogger(RefactoringController.class);
 
 	/**
 	 * This method performs refactorings with comments within Pull-Requests of a
@@ -77,6 +83,7 @@ public class RefactoringController {
 
 		// Create empty list of refactored Issues
 		List<RefactoredIssue> allRefactoredIssues = new ArrayList<RefactoredIssue>();
+		Integer amountBotRequests = 0;
 
 		Optional<GitConfiguration> gitConfig;
 		try {
@@ -84,7 +91,7 @@ public class RefactoringController {
 			gitConfig = configRepo.getByID(configID);
 		} catch (Exception e) {
 			// Print exception and abort if database error occurs
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 		// If Configuration does not exist
@@ -99,8 +106,17 @@ public class RefactoringController {
 			dataGetter.fetchRemote(gitConfig.get());
 			// Get Pull-Requests with comments
 			allRequests = grabber.getRequestsWithComments(gitConfig.get());
+			amountBotRequests = botController.getAmountOfBotRequests(allRequests, gitConfig.get());
+
+			// Check if max amount is reached
+			if (amountBotRequests >= gitConfig.get().getMaxAmountRequests()) {
+				return new ResponseEntity<String>(
+						"Maximal amount of requests reached." + "(Maximum = " + gitConfig.get().getMaxAmountRequests()
+								+ "; Currently = " + amountBotRequests + " bot requests are open)",
+						HttpStatus.BAD_REQUEST);
+			}
 		} catch (Exception e) {
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			return new ResponseEntity<String>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 
@@ -108,6 +124,13 @@ public class RefactoringController {
 		for (BotPullRequest request : allRequests.getAllPullRequests()) {
 			// Iterate through all comments
 			for (BotPullRequestComment comment : request.getAllComments()) {
+
+				// When Bot-Pull-Request-Limit reached -> return
+				if (amountBotRequests >= gitConfig.get().getMaxAmountRequests()) {
+					// Return all refactored issues
+					return new ResponseEntity<List<RefactoredIssue>>(allRefactoredIssues, HttpStatus.OK);
+				}
+
 				// Check if comment is valid and not already refactored
 				if (grammarController.checkComment(comment.getCommentBody()) && !issueRepo
 						.refactoredComment(gitConfig.get().getRepoService(), comment.getCommentID().toString())
@@ -117,6 +140,7 @@ public class RefactoringController {
 					try {
 						botIssue = grammarController.createIssueFromComment(comment);
 					} catch (Exception e) {
+						logger.error(e.getMessage(), e);
 						return new ResponseEntity<String>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
 					}
 
@@ -126,24 +150,28 @@ public class RefactoringController {
 							// Create refactoring branch with Filehoster-Service + Comment-ID
 							String newBranch = gitConfig.get().getRepoService() + "_Refactoring_"
 									+ comment.getCommentID().toString();
+							// Check if branch already exists (throws exception if it does)
+							grabber.checkBranch(gitConfig.get(), newBranch);
+							// Create new Branch
 							dataGetter.createBranch(gitConfig.get(), request.getBranchName(), newBranch);
 
 							// Try to refactor
-							String commitMessage = refactoring.pickAndRefactor(botIssue, gitConfig.get());
+							botIssue.setCommitMessage(refactoring.pickAndRefactor(botIssue, gitConfig.get()));
 
 							// If successful
-							if (commitMessage != null) {
+							if (botIssue.getCommitMessage() != null) {
 								// Create Refactored-Obect
 								RefactoredIssue refactoredIssue = botController.buildRefactoredIssue(botIssue,
 										gitConfig.get());
 
+								// Push changes + create Pull-Request
+								dataGetter.pushChanges(gitConfig.get(), botIssue.getCommitMessage());
+								grabber.makeCreateRequest(request, comment, gitConfig.get(), newBranch);
+
 								// Save to Database + add to list
 								RefactoredIssue savedIssue = refactoredIssues.save(refactoredIssue);
 								allRefactoredIssues.add(savedIssue);
-
-								// Push changes + create Pull-Request
-								dataGetter.pushChanges(gitConfig.get(), commitMessage);
-								grabber.makeCreateRequest(request, comment, gitConfig.get(), newBranch);
+								amountBotRequests++;
 							}
 							// For Requests created by the bot
 						} else {
@@ -151,26 +179,59 @@ public class RefactoringController {
 							dataGetter.switchBranch(gitConfig.get(), request.getBranchName());
 
 							// Try to refactor
-							String commitMessage = refactoring.pickAndRefactor(botIssue, gitConfig.get());
+							botIssue.setCommitMessage(refactoring.pickAndRefactor(botIssue, gitConfig.get()));
 
 							// If successful
-							if (commitMessage != null) {
+							if (botIssue.getCommitMessage() != null) {
 								// Create Refactored-Object
 								RefactoredIssue refactoredIssue = botController.buildRefactoredIssue(botIssue,
 										gitConfig.get());
 
+								// Push changes
+								dataGetter.pushChanges(gitConfig.get(), botIssue.getCommitMessage());
+
 								// Save to Database + add to list
 								RefactoredIssue savedIssue = refactoredIssues.save(refactoredIssue);
 								allRefactoredIssues.add(savedIssue);
-
-								// Push changes + edit Pull-Request
-								dataGetter.pushChanges(gitConfig.get(), commitMessage);
-								grabber.makeUpdateRequest(request, comment, gitConfig.get());
 							}
 						}
+						// Catch refactoring errors
+					} catch (BotRefactoringException e) {
+						// Create failed Refactored-Object
+						botIssue.setErrorMessage(e.getMessage());
+						RefactoredIssue failedIssue = botController.buildRefactoredIssue(botIssue, gitConfig.get());
+
+						// Reply to user
+						try {
+							grabber.replyToUserForFailedRefactoring(request, comment, gitConfig.get(),
+									botIssue.getErrorMessage());
+						} catch (Exception u) {
+							logger.error(u.getMessage(), u);
+						}
+
+						// Save failed refactoring to database + add to list
+						RefactoredIssue savedFailIssue = refactoredIssues.save(failedIssue);
+						allRefactoredIssues.add(savedFailIssue);
+						logger.error(e.getMessage(), e);
+
+						// Catch other errors
 					} catch (Exception e) {
-						e.printStackTrace();
-						return new ResponseEntity<String>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+						// Create failed Refactored-Object
+						botIssue.setErrorMessage("Bot could not refactor this comment! Internal server error!");
+						RefactoredIssue failedIssue = botController.buildRefactoredIssue(botIssue, gitConfig.get());
+
+						// Reply to user
+						try {
+							grabber.replyToUserForFailedRefactoring(request, comment, gitConfig.get(),
+									botIssue.getErrorMessage());
+						} catch (Exception u) {
+							logger.error(u.getMessage(), u);
+						}
+
+						// Save failed refactoring to database + add to list
+						RefactoredIssue savedFailIssue = refactoredIssues.save(failedIssue);
+						allRefactoredIssues.add(savedFailIssue);
+						logger.error(e.getMessage(), e);
 					}
 				}
 			}
@@ -193,6 +254,7 @@ public class RefactoringController {
 
 		// Create empty list of refactored Issues
 		List<RefactoredIssue> allRefactoredIssues = new ArrayList<RefactoredIssue>();
+		Integer amountBotRequests = 0;
 
 		Optional<GitConfiguration> gitConfig;
 		try {
@@ -200,7 +262,7 @@ public class RefactoringController {
 			gitConfig = configRepo.getByID(configID);
 		} catch (Exception e) {
 			// Print exception and abort if database error occurs
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			return new ResponseEntity<String>("Connection with database failed!", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 		// If configuration does not exist
@@ -216,10 +278,19 @@ public class RefactoringController {
 		try {
 			// Fetch target-Repository-data
 			dataGetter.fetchRemote(gitConfig.get());
-			// Check if max amount of Requests reached
-			grabber.getRequestsWithComments(gitConfig.get());
+			// Get Pull-Requests with comments
+			BotPullRequests allRequests = grabber.getRequestsWithComments(gitConfig.get());
+			amountBotRequests = botController.getAmountOfBotRequests(allRequests, gitConfig.get());
+
+			// Check if max amount is reached
+			if (amountBotRequests >= gitConfig.get().getMaxAmountRequests()) {
+				return new ResponseEntity<String>(
+						"Maximal amount of requests reached." + "(Maximum = " + gitConfig.get().getMaxAmountRequests()
+								+ "; Currently = " + amountBotRequests + " bot requests are open)",
+						HttpStatus.BAD_REQUEST);
+			}
 		} catch (Exception e) {
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			return new ResponseEntity<String>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 
@@ -236,33 +307,56 @@ public class RefactoringController {
 
 			// Iterate all issues
 			for (BotIssue botIssue : botIssues) {
-				// If issue was not already refactored
-				if (!issueRepo.refactoredAnalysisIssue(botIssue.getCommentServiceID()).isPresent()) {
-					// Create new branch for refactoring
-					String newBranch = "sonarCube_Refactoring_" + botIssue.getCommentServiceID();
-					dataGetter.createBranch(gitConfig.get(), "master", newBranch);
-					// Try to refactor
-					String commitMessage = refactoring.pickAndRefactor(botIssue, gitConfig.get());
 
-					// If successful
-					if (commitMessage != null) {
-						// Create Refactored-Object
-						RefactoredIssue refactoredIssue = botController.buildRefactoredIssue(botIssue, gitConfig.get());
+				// When Bot-Pull-Request-Limit reached -> return
+				if (amountBotRequests >= gitConfig.get().getMaxAmountRequests()) {
+					// Return all refactored issues
+					return new ResponseEntity<List<RefactoredIssue>>(allRefactoredIssues, HttpStatus.OK);
+				}
 
-						// Save to database + add to list
-						RefactoredIssue savedIssue = refactoredIssues.save(refactoredIssue);
-						allRefactoredIssues.add(savedIssue);
+				try {
+					// If issue was not already refactored
+					if (!issueRepo.refactoredAnalysisIssue(botIssue.getCommentServiceID()).isPresent()) {
+						// Create new branch for refactoring
+						String newBranch = "sonarCube_Refactoring_" + botIssue.getCommentServiceID();
+						// Check if branch already exists (throws exception if it does)
+						grabber.checkBranch(gitConfig.get(), newBranch);
+						dataGetter.createBranch(gitConfig.get(), "master", newBranch);
+						// Try to refactor
+						botIssue.setCommitMessage(refactoring.pickAndRefactor(botIssue, gitConfig.get()));
 
-						// Push changes + create Pull-Request
-						dataGetter.pushChanges(gitConfig.get(), commitMessage);
-						grabber.makeCreateRequestWithAnalysisService(botIssue, gitConfig.get(), newBranch);
+						// If successful
+						if (botIssue.getCommitMessage() != null) {
+							// Create Refactored-Object
+							RefactoredIssue refactoredIssue = botController.buildRefactoredIssue(botIssue,
+									gitConfig.get());
+
+							// Push changes + create Pull-Request
+							dataGetter.pushChanges(gitConfig.get(), botIssue.getCommitMessage());
+							grabber.makeCreateRequestWithAnalysisService(botIssue, gitConfig.get(), newBranch);
+
+							// Save to database + add to list
+							RefactoredIssue savedIssue = refactoredIssues.save(refactoredIssue);
+							allRefactoredIssues.add(savedIssue);
+
+							amountBotRequests++;
+						}
 					}
+				} catch (Exception e) {
+					// Create failed Refactored-Object
+					botIssue.setErrorMessage("Bot could not refactor this comment! Internal server error!");
+					RefactoredIssue failedIssue = botController.buildRefactoredIssue(botIssue, gitConfig.get());
+
+					// Save failed refactoring to database + add to list
+					RefactoredIssue savedFailIssue = refactoredIssues.save(failedIssue);
+					allRefactoredIssues.add(savedFailIssue);
+					logger.error(e.getMessage(), e);
 				}
 			}
 
 			return new ResponseEntity<List<RefactoredIssue>>(allRefactoredIssues, HttpStatus.OK);
 		} catch (Exception e) {
-			e.printStackTrace();
+			logger.error(e.getMessage(), e);
 			return new ResponseEntity<String>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 	}

--- a/src/main/java/de/refactoringBot/rest/RefactoringController.java
+++ b/src/main/java/de/refactoringBot/rest/RefactoringController.java
@@ -9,9 +9,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import de.refactoringBot.api.main.ApiGrabber;
@@ -77,7 +77,7 @@ public class RefactoringController {
 	 * @param configID
 	 * @return allRequests
 	 */
-	@RequestMapping(value = "/refactorWithComments/{configID}", method = RequestMethod.GET, produces = "application/json")
+	@GetMapping(value = "/refactorWithComments/{configID}", produces = "application/json")
 	@ApiOperation(value = "Perform refactorings with Pull-Request-Comments.")
 	public ResponseEntity<?> refactorWithComments(@PathVariable Long configID) {
 
@@ -250,7 +250,7 @@ public class RefactoringController {
 	 * @param configID
 	 * @return allRefactoredIssues
 	 */
-	@RequestMapping(value = "/refactorWithAnalysisService/{configID}", method = RequestMethod.GET, produces = "application/json")
+	@GetMapping(value = "/refactorWithAnalysisService/{configID}", produces = "application/json")
 	@ApiOperation(value = "Perform refactorings with analysis service.")
 	public ResponseEntity<?> refactorWithSonarCube(@PathVariable Long configID) {
 

--- a/src/main/java/de/refactoringBot/rest/RefactoringController.java
+++ b/src/main/java/de/refactoringBot/rest/RefactoringController.java
@@ -189,6 +189,8 @@ public class RefactoringController {
 
 								// Push changes
 								dataGetter.pushChanges(gitConfig.get(), botIssue.getCommitMessage());
+								// Reply to User
+								grabber.replyToUserInsideBotRequest(request, comment, gitConfig.get());
 
 								// Save to Database + add to list
 								RefactoredIssue savedIssue = refactoredIssues.save(refactoredIssue);

--- a/src/main/java/de/refactoringBot/rest/RefactoringController.java
+++ b/src/main/java/de/refactoringBot/rest/RefactoringController.java
@@ -153,7 +153,7 @@ public class RefactoringController {
 							// Check if branch already exists (throws exception if it does)
 							grabber.checkBranch(gitConfig.get(), newBranch);
 							// Create new Branch
-							dataGetter.createBranch(gitConfig.get(), request.getBranchName(), newBranch);
+							dataGetter.createBranch(gitConfig.get(), request.getBranchName(), newBranch, "upstream");
 
 							// Try to refactor
 							botIssue.setCommitMessage(refactoring.pickAndRefactor(botIssue, gitConfig.get()));
@@ -323,7 +323,7 @@ public class RefactoringController {
 						String newBranch = "sonarCube_Refactoring_" + botIssue.getCommentServiceID();
 						// Check if branch already exists (throws exception if it does)
 						grabber.checkBranch(gitConfig.get(), newBranch);
-						dataGetter.createBranch(gitConfig.get(), "master", newBranch);
+						dataGetter.createBranch(gitConfig.get(), "master", newBranch, "upstream");
 						// Try to refactor
 						botIssue.setCommitMessage(refactoring.pickAndRefactor(botIssue, gitConfig.get()));
 

--- a/src/test/java/de/refactoringBot/RefactoringBotApplicationTest.java
+++ b/src/test/java/de/refactoringBot/RefactoringBotApplicationTest.java
@@ -1,10 +1,6 @@
 package de.refactoringBot;
 
-import org.junit.runner.RunWith;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
-
-@RunWith(SpringRunner.class)
-@SpringBootTest
+// @RunWith(SpringRunner.class)
+// @SpringBootTest
 public class RefactoringBotApplicationTest {
 }

--- a/src/test/java/de/refactoringBot/RefactoringBotApplicationTest.java
+++ b/src/test/java/de/refactoringBot/RefactoringBotApplicationTest.java
@@ -1,6 +1,5 @@
 package de.refactoringBot;
 
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -8,9 +7,4 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class RefactoringBotApplicationTest {
-
-	@Test
-	public void contextLoads() {
-	}
-
 }

--- a/src/test/java/de/refactoringBot/RefactoringBotApplicationTest.java
+++ b/src/test/java/de/refactoringBot/RefactoringBotApplicationTest.java
@@ -1,4 +1,4 @@
-package de.BA.gitHubApi;
+package de.refactoringBot;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -7,7 +7,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-public class GitHubApiTestApplicationTests {
+public class RefactoringBotApplicationTest {
 
 	@Test
 	public void contextLoads() {


### PR DESCRIPTION
**Changed exception handling**
- Added, removed and repositioned some exceptions for clearer feedback to user.
- Exceptions will be logged via. logger instead of printed (like: https://github.com/Refactoring-Bot/Refactoring-Bot/pull/8)

**Bot now saves any refactoring, no matter if it failed or not**
-  If a refactoring fails, it will still be saved to the database with a 'failed' mark, so that the user knows that the refactoring failed -> Bot will never again retry to refactor the same comments over and over again (and useful if some sort of statistics are added in the future)

**Added further refactoring checks after the database was reset**
- If a user resets the database the fork on a filehosting website stays. When the configuration is created again, all requests, comments and fork-branches still exist, but the database is empty. If the bot tries to refactor some comment again, then: 
1. If comment was in bot pull request: Local branch does not exist. Bot will create it with the data from the origin-remote and try to refactor. If comment was already refactored it will either throw an error (method line changed and comment is outdated for example) or the bot will not change anything, which will also lead to an error.
2. If comment was in other users pull request: Bot will check if comment was already refactored (if yes, then the bot should have a branch on his fork with the specific ID). If he does he will throw an error, saying the comment was already refactored, if not he will try to refactor the comment again
