### PR TITLE
add sonarcloud badge on readme page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/Refactoring-Bot/Refactoring-Bot.svg?branch=master)](https://travis-ci.org/Refactoring-Bot/Refactoring-Bot)
 
+[![Sonarcloud Dashboard](https://sonarcloud.io/images/project_badges/sonarcloud-white.svg)](https://sonarcloud.io/dashboard?id=de.refactoringBot:RefactoringBot)
+
 Implementation of a bot that performs automatic refactorings based on the results of static code analysis or comments in pull requests. The changes are made available to the developers as pull requests for easy review.
 
 Learn more about the bot and how to use it in the [wiki](https://github.com/Refactoring-Bot/Refactoring-Bot/wiki).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Refactoring-Bot
 
-[![Build Status](https://travis-ci.org/Refactoring-Bot/Refactoring-Bot.svg?branch=master)](https://travis-ci.org/Refactoring-Bot/Refactoring-Bot)
-
-[![Sonarcloud Dashboard](https://sonarcloud.io/images/project_badges/sonarcloud-white.svg)](https://sonarcloud.io/dashboard?id=de.refactoringBot:RefactoringBot)
+[![Build Status](https://travis-ci.org/Refactoring-Bot/Refactoring-Bot.svg?branch=master)](https://travis-ci.org/Refactoring-Bot/Refactoring-Bot) 
+[![Sonarcloud Dashboard](https://sonarcloud.io/api/project_badges/measure?project=de.refactoringBot%3ARefactoringBot&metric=alert_status)](https://sonarcloud.io/dashboard?id=de.refactoringBot%3ARefactoringBot) 
 
 Implementation of a bot that performs automatic refactorings based on the results of static code analysis or comments in pull requests. The changes are made available to the developers as pull requests for easy review.
 


### PR DESCRIPTION
as alternative a smaller badge with a metric would also be possible. But I was not sure which one to choose.