### PR TITLE
add tests to GithubObjectTranslator

### DIFF
--- a/src/main/java/de/refactoringbot/controller/github/GithubObjectTranslator.java
+++ b/src/main/java/de/refactoringbot/controller/github/GithubObjectTranslator.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import de.refactoringbot.api.github.GithubDataGrabber;
-import de.refactoringbot.configuration.BotConfiguration;
 import de.refactoringbot.model.botissue.BotIssue;
 import de.refactoringbot.model.configuration.GitConfiguration;
 import de.refactoringbot.model.configuration.GitConfigurationDTO;
@@ -39,23 +38,21 @@ import de.refactoringbot.model.output.botpullrequestcomment.BotPullRequestCommen
 @Component
 public class GithubObjectTranslator {
 
-	@Autowired
-	GithubDataGrabber grabber;
-	@Autowired
-	BotConfiguration botConfig;
-	@Autowired
-	ModelMapper modelMapper;
-
 	private static final Logger logger = LoggerFactory.getLogger(GithubObjectTranslator.class);
+
+	private final GithubDataGrabber grabber;
+	private final ModelMapper modelMapper;
+
+	@Autowired
+	public GithubObjectTranslator(GithubDataGrabber grabber, ModelMapper modelMapper) {
+		this.grabber = grabber;
+		this.modelMapper = modelMapper;
+	}
 
 	/**
 	 * This method creates a GitConfiguration from GitHub data.
 	 * 
-	 * @param repo
-	 * @param repoService
-	 * @param analysusServiceProjectKey
-	 * @param maxAmountRequests
-	 * @param projectRootFolder
+	 * @param configuration
 	 * @return
 	 */
 	public GitConfiguration createConfiguration(GitConfigurationDTO configuration) {
@@ -280,7 +277,7 @@ public class GithubObjectTranslator {
 	 * This method creates a reply comment for a failed refactoring that was
 	 * triggered by a comment of a pull request.
 	 * 
-	 * @param comment
+	 * @param replyTo
 	 * @param errorMessage
 	 * @return
 	 */

--- a/src/test/java/de/refactoringbot/controller/github/GithubObjectTranslatorTest.java
+++ b/src/test/java/de/refactoringbot/controller/github/GithubObjectTranslatorTest.java
@@ -1,14 +1,15 @@
 package de.refactoringbot.controller.github;
 
-import de.refactoringbot.model.configuration.GitConfiguration;
-import de.refactoringbot.model.configuration.GitConfigurationDTO;
-import de.refactoringbot.model.github.pullrequestcomment.ReplyComment;
-import de.refactoringbot.model.output.botpullrequestcomment.BotPullRequestComment;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.assertj.core.api.SoftAssertions;
 import org.junit.Test;
 import org.modelmapper.ModelMapper;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import de.refactoringbot.model.configuration.GitConfiguration;
+import de.refactoringbot.model.configuration.GitConfigurationDTO;
+import de.refactoringbot.model.github.pullrequestcomment.ReplyComment;
+import de.refactoringbot.model.output.botpullrequestcomment.BotPullRequestComment;
 
 public class GithubObjectTranslatorTest {
 
@@ -29,7 +30,7 @@ public class GithubObjectTranslatorTest {
 		comment.setCommentID(commentId);
 		String errorMessage = "test error message";
 
-		GithubObjectTranslator  githubObjectTranslator = new GithubObjectTranslator(null, null);
+		GithubObjectTranslator githubObjectTranslator = new GithubObjectTranslator(null, null);
 		ReplyComment failureReply = githubObjectTranslator.createFailureReply(comment, errorMessage);
 
 		SoftAssertions softAssertions = new SoftAssertions();
@@ -38,13 +39,12 @@ public class GithubObjectTranslatorTest {
 		softAssertions.assertAll();
 	}
 
-
 	@Test
 	public void createConfiguration() {
 		GitConfigurationDTO configurationDto = createGitConfigurationDto();
 
 		ModelMapper modelMapper = new ModelMapper();
-		GithubObjectTranslator  githubObjectTranslator = new GithubObjectTranslator(null, modelMapper);
+		GithubObjectTranslator githubObjectTranslator = new GithubObjectTranslator(null, modelMapper);
 		GitConfiguration gitConfiguration = githubObjectTranslator.createConfiguration(configurationDto);
 
 		GitConfiguration expectedGitConfiguration = createExpectedGitConfiguration();

--- a/src/test/java/de/refactoringbot/controller/github/GithubObjectTranslatorTest.java
+++ b/src/test/java/de/refactoringbot/controller/github/GithubObjectTranslatorTest.java
@@ -1,0 +1,88 @@
+package de.refactoringbot.controller.github;
+
+import de.refactoringbot.model.configuration.GitConfiguration;
+import de.refactoringbot.model.configuration.GitConfigurationDTO;
+import de.refactoringbot.model.github.pullrequestcomment.ReplyComment;
+import de.refactoringbot.model.output.botpullrequestcomment.BotPullRequestComment;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+import org.modelmapper.ModelMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GithubObjectTranslatorTest {
+
+	private final String repositoryOwner = "testRepositoryOwner";
+	private final String repositoryName = "testRepositoryName";
+	private final String botName = "testBotName";
+	private final String analysisService = "testAnalysisName";
+	private final String botEmail = "testBotEmail";
+	private final String analysisKey = "testAnalysisKey";
+	private final String botToken = "testBotToken";
+	private final String repositoryService = "testRepositoryService";
+	private final Integer maxRequests = 456;
+
+	@Test
+	public void createFailureReply() {
+		BotPullRequestComment comment = new BotPullRequestComment();
+		Integer commentId = 123;
+		comment.setCommentID(commentId);
+		String errorMessage = "test error message";
+
+		GithubObjectTranslator  githubObjectTranslator = new GithubObjectTranslator(null, null);
+		ReplyComment failureReply = githubObjectTranslator.createFailureReply(comment, errorMessage);
+
+		SoftAssertions softAssertions = new SoftAssertions();
+		softAssertions.assertThat(failureReply.getIn_reply_to()).isEqualTo(commentId);
+		softAssertions.assertThat(failureReply.getBody()).isEqualTo(errorMessage);
+		softAssertions.assertAll();
+	}
+
+
+	@Test
+	public void createConfiguration() {
+		GitConfigurationDTO configurationDto = createGitConfigurationDto();
+
+		ModelMapper modelMapper = new ModelMapper();
+		GithubObjectTranslator  githubObjectTranslator = new GithubObjectTranslator(null, modelMapper);
+		GitConfiguration gitConfiguration = githubObjectTranslator.createConfiguration(configurationDto);
+
+		GitConfiguration expectedGitConfiguration = createExpectedGitConfiguration();
+
+		assertThat(gitConfiguration).isEqualToComparingFieldByField(expectedGitConfiguration);
+	}
+
+	private GitConfigurationDTO createGitConfigurationDto() {
+		GitConfigurationDTO configurationDto = new GitConfigurationDTO();
+		configurationDto.setAnalysisService(analysisService);
+		configurationDto.setAnalysisServiceProjectKey(analysisKey);
+		configurationDto.setBotName(botName);
+		configurationDto.setBotEmail(botEmail);
+		configurationDto.setBotToken(botToken);
+		configurationDto.setRepoOwner(repositoryOwner);
+		configurationDto.setRepoName(repositoryName);
+		configurationDto.setRepoService(repositoryService);
+		configurationDto.setMaxAmountRequests(maxRequests);
+		return configurationDto;
+	}
+
+	private GitConfiguration createExpectedGitConfiguration() {
+		GitConfiguration gitConfiguration = new GitConfiguration();
+		gitConfiguration.setAnalysisService(analysisService.toLowerCase());
+		gitConfiguration.setAnalysisServiceProjectKey(analysisKey);
+		gitConfiguration.setBotName(botName);
+		gitConfiguration.setBotEmail(botEmail);
+		gitConfiguration.setBotToken(botToken);
+		gitConfiguration.setRepoName(repositoryName);
+		gitConfiguration.setRepoOwner(repositoryOwner);
+		gitConfiguration.setRepoService(repositoryService);
+		gitConfiguration.setMaxAmountRequests(maxRequests);
+
+		gitConfiguration.setRepoApiLink("https://api.github.com/repos/" + repositoryOwner + "/" + repositoryName);
+		gitConfiguration.setRepoGitLink("https://github.com/" + repositoryOwner + "/" + repositoryName + ".git");
+		gitConfiguration.setForkApiLink("https://api.github.com/repos/" + botName + "/" + repositoryName);
+		gitConfiguration.setForkGitLink("https://github.com/" + botName + "/" + repositoryName + ".git");
+
+		return gitConfiguration;
+	}
+}


### PR DESCRIPTION
tested 2 methods of GithubObjectTranslator.

Field injection replaced with constructor injection to make the class testable without the need to create an injection context.