### PR TITLE
Removed Dockerfile and provided link to Docker repo in README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM java:8-alpine
-LABEL maintainer="Marvin Wyrich <mail@marvin-wyrich.de>"
-
-# copy the created jar file to the image (make sure it exists ==> `mvn clean install`)
-COPY target/RefactoringBot-0.0.1-SNAPSHOT.jar /opt/refactoring-bot/RefactoringBot-0.0.1-SNAPSHOT.jar
-
-ENV LOCAL_DIR=/opt/refactoring-bot/repos
-CMD ["java","-jar","/opt/refactoring-bot/RefactoringBot-0.0.1-SNAPSHOT.jar"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Implementation of a bot that performs automatic refactorings based on the result
 Learn more about the bot and how to use it in the [wiki](https://github.com/Refactoring-Bot/Refactoring-Bot/wiki).
 
 ## Developer Usage Instructions
-
 Before you can use the bot locally, the following steps need to be executed.
 
 1. The bot needs access to a MySQL DB instance to save its data. Use an existing one, download MySQL for your OS, or create a docker container via `docker run --name refactoring-bot-db -p 3306:3306 -e MYSQL_ROOT_PASSWORD=root -d mysql:latest`.
@@ -17,28 +16,5 @@ Before you can use the bot locally, the following steps need to be executed.
 4. Execute the command `mvn install` to create the executable JAR file for the bot.
 5. Run the created JAR file via `java -jar ./target/RefactoringBot-0.0.1-SNAPSHOT.jar`. The API should now be available at `http://localhost:8808` and the SwaggerUI will open in the browser.
 
-## Docker Container
-
-Use the following instructions to handle a local Docker image and container of the Refactoring-Bot.
-
-```bash
-# Make sure the jar file has been built and is available in the `target` directory
-# If not execute the following command
-mvn clean install
-
-# Build image from Dockerfile
-docker build -t refactoring-bot .
-
-# Create container from image, exposing port 8808, and setting the host for the DB via an ENV variable
-# (if the DB is also in a Docker container, use `docker inspect <container-name>` to find out its IP)
-docker create --name refactoring-bot \
-    -p 8808:8808 \
-    -e DATABASE_HOST=172.17.0.2 \
-    refactoring-bot:latest
-
-# Start container
-docker start refactoring-bot
-
-# Optional: open interactive shell to connect to a running container (yes, `ash` is the shell in alpine, this is no typo)
-docker exec -it refactoring-bot ash
-```
+## Docker Support
+Please refer to our [Docker Repository](https://github.com/Refactoring-Bot/Docker) for detailed usage instructions with `docker` or `docker-compose`.


### PR DESCRIPTION
I created a separate repo for everything Docker related: https://github.com/Refactoring-Bot/Docker

I therefore removed the `Dockerfile` from this repo and provided a link to the new repo in the `README`.