### PR TITLE
Implement refactoring to immediately return expression instead of assigning it to a local variable

### DIFF
--- a/src/main/java/de/refactoringbot/refactoring/RefactoringHelper.java
+++ b/src/main/java/de/refactoringbot/refactoring/RefactoringHelper.java
@@ -20,6 +20,8 @@ import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
@@ -91,14 +93,13 @@ public class RefactoringHelper {
 	 * @return MethodDeclaration or null if none found
 	 */
 	public static MethodDeclaration getMethodDeclarationByLineNumber(int lineNumber, CompilationUnit cu) {
-		MethodDeclaration result = null;
 		List<MethodDeclaration> methods = cu.findAll(MethodDeclaration.class);
 		for (MethodDeclaration method : methods) {
 			if (isMethodDeclarationAtLine(method, lineNumber)) {
-				result = method;
+				return method;
 			}
 		}
-		return result;
+		return null;
 	}
 
 	/**
@@ -112,6 +113,26 @@ public class RefactoringHelper {
 	}
 
 	/**
+	 * Finds a method declaration in a compilation unit that surrounds the given
+	 * line somewhere in the method body
+	 * 
+	 * @param lineSomewhereInMethodBody
+	 * @param cu
+	 * @return MethodDeclaration or null if none found
+	 */
+	public static MethodDeclaration getMethodDeclarationByLineNumberInMethod(int lineSomewhereInMethodBody,
+			CompilationUnit cu) {
+		while (lineSomewhereInMethodBody > 0) {
+			MethodDeclaration m = getMethodDeclarationByLineNumber(lineSomewhereInMethodBody, cu);
+			if (m != null) {
+				return m;
+			}
+			lineSomewhereInMethodBody--;
+		}
+		return null;
+	}
+
+	/**
 	 * Finds a field declaration in a compilation unit that starts at the specified
 	 * line number
 	 * 
@@ -120,14 +141,13 @@ public class RefactoringHelper {
 	 * @return FieldDeclaration or null if none found
 	 */
 	public static FieldDeclaration getFieldDeclarationByLineNumber(int lineNumber, CompilationUnit cu) {
-		FieldDeclaration result = null;
 		List<FieldDeclaration> fields = cu.findAll(FieldDeclaration.class);
 		for (FieldDeclaration field : fields) {
 			if (isFieldDeclarationAtLine(field, lineNumber)) {
-				result = field;
+				return field;
 			}
 		}
-		return result;
+		return null;
 	}
 
 	/**
@@ -138,6 +158,36 @@ public class RefactoringHelper {
 	public static boolean isFieldDeclarationAtLine(FieldDeclaration fieldDeclaration, Integer lineNumber) {
 		Optional<Position> beginPositionOfField = fieldDeclaration.getBegin();
 		return (beginPositionOfField.isPresent() && beginPositionOfField.get().line == lineNumber);
+	}
+
+	public static ExpressionStmt getExpressionStmtByLineNumber(int lineNumber, CompilationUnit cu) {
+		List<ExpressionStmt> stmts = cu.findAll(ExpressionStmt.class);
+		for (ExpressionStmt stmt : stmts) {
+			if (isExpressionStmtAtLine(stmt, lineNumber)) {
+				return stmt;
+			}
+		}
+		return null;
+	}
+
+	private static boolean isExpressionStmtAtLine(ExpressionStmt stmt, int lineNumber) {
+		Optional<Position> beginPositionOfStatement = stmt.getBegin();
+		return (beginPositionOfStatement.isPresent() && beginPositionOfStatement.get().line == lineNumber);
+	}
+
+	public static VariableDeclarationExpr getVariableDeclarationExprByLineNumber(int lineNumber, CompilationUnit cu) {
+		List<VariableDeclarationExpr> expressions = cu.findAll(VariableDeclarationExpr.class);
+		for (VariableDeclarationExpr expression : expressions) {
+			if (isVariableDeclarationExprAtLine(expression, lineNumber)) {
+				return expression;
+			}
+		}
+		return null;
+	}
+
+	private static boolean isVariableDeclarationExprAtLine(VariableDeclarationExpr expression, int lineNumber) {
+		Optional<Position> beginPositionOfExpr = expression.getBegin();
+		return (beginPositionOfExpr.isPresent() && beginPositionOfExpr.get().line == lineNumber);
 	}
 
 	/**

--- a/src/main/java/de/refactoringbot/refactoring/RefactoringOperations.java
+++ b/src/main/java/de/refactoringbot/refactoring/RefactoringOperations.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.springframework.stereotype.Component;
 
 import de.refactoringbot.refactoring.supportedrefactorings.AddOverrideAnnotation;
+import de.refactoringbot.refactoring.supportedrefactorings.ImmediatelyReturnExpression;
 import de.refactoringbot.refactoring.supportedrefactorings.RemoveCommentedOutCode;
 import de.refactoringbot.refactoring.supportedrefactorings.RemoveMethodParameter;
 import de.refactoringbot.refactoring.supportedrefactorings.RenameMethod;
@@ -26,6 +27,7 @@ public class RefactoringOperations {
 	public static final String REORDER_MODIFIER = "Reorder Modifier";
 	public static final String REMOVE_COMMENTED_OUT_CODE = "Remove Commented Out Code";
 	public static final String REMOVE_PARAMETER = "Remove Parameter";
+	public static final String IMMEDIATELY_RETURN_EXPRESSION = "Immediately return expression";
 	public static final String UNKNOWN = "Unknown Refactoring";
 
 	/**
@@ -41,6 +43,7 @@ public class RefactoringOperations {
 		ruleToClassMapping.put(RENAME_METHOD, RenameMethod.class);
 		ruleToClassMapping.put(REMOVE_COMMENTED_OUT_CODE, RemoveCommentedOutCode.class);
 		ruleToClassMapping.put(REMOVE_PARAMETER, RemoveMethodParameter.class);
+		ruleToClassMapping.put(IMMEDIATELY_RETURN_EXPRESSION, ImmediatelyReturnExpression.class);
 
 		return ruleToClassMapping;
 	}

--- a/src/main/java/de/refactoringbot/refactoring/supportedrefactorings/ImmediatelyReturnExpression.java
+++ b/src/main/java/de/refactoringbot/refactoring/supportedrefactorings/ImmediatelyReturnExpression.java
@@ -1,0 +1,106 @@
+package de.refactoringbot.refactoring.supportedrefactorings;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.PrintWriter;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+
+import de.refactoringbot.model.botissue.BotIssue;
+import de.refactoringbot.model.configuration.GitConfiguration;
+import de.refactoringbot.model.exceptions.BotRefactoringException;
+import de.refactoringbot.refactoring.RefactoringHelper;
+import de.refactoringbot.refactoring.RefactoringImpl;
+
+/**
+ * Immediately returns an expression if the return statement directly follows an
+ * assignment to a local variable. Throws an exception if the variable is used
+ * more than once.<br>
+ * 
+ * Example:<br>
+ * {@code int a = 5 * b;}<br>
+ * {@code return a;} <br>
+ * becomes <br>
+ * {@code return 5 * b;}
+ */
+public class ImmediatelyReturnExpression implements RefactoringImpl {
+
+	@Override
+	public String performRefactoring(BotIssue issue, GitConfiguration gitConfig) throws Exception {
+		String issueFilePath = gitConfig.getRepoFolder() + File.separator + issue.getFilePath();
+		int lineWithStmtToBeReturned = issue.getLine();
+
+		FileInputStream in = new FileInputStream(issueFilePath);
+		CompilationUnit cu = LexicalPreservingPrinter.setup(JavaParser.parse(in));
+
+		MethodDeclaration targetMethod = RefactoringHelper
+				.getMethodDeclarationByLineNumberInMethod(lineWithStmtToBeReturned, cu);
+		if (targetMethod == null) {
+			throw new BotRefactoringException(
+					"Could not find a method that contains the code position to be improved!");
+		}
+
+		VariableDeclarator variableDeclarator = findVariableDeclarator(lineWithStmtToBeReturned, cu);		
+		Optional<Expression> initializer = variableDeclarator.getInitializer(); // expression to be returned later
+		if (!initializer.isPresent()) {
+			throw new BotRefactoringException("Could not find an initializer of the variable declarator.");
+		}
+
+		String variableName = variableDeclarator.getNameAsString();
+		List<ReturnStmt> returnStmts = findCorrespondingReturnStmts(variableName, targetMethod);
+		if (returnStmts.isEmpty()) {
+			throw new BotRefactoringException(
+					"Could not find the corresponding return statement for variable " + variableName + ".");
+		}
+		if (returnStmts.size() > 1) {
+			throw new BotRefactoringException("Variable is used in more than one return statement.");
+		}
+
+		returnStmts.get(0).setExpression(JavaParser.parseExpression(initializer.get().toString()));
+
+		ExpressionStmt expression = RefactoringHelper.getExpressionStmtByLineNumber(lineWithStmtToBeReturned, cu);
+		expression.remove();
+
+		PrintWriter out = new PrintWriter(issueFilePath);
+		out.println(LexicalPreservingPrinter.print(cu));
+		out.close();
+
+		return "Immediately return the expression assigned to variable '" + variableName + "'.";
+	}
+
+	protected VariableDeclarator findVariableDeclarator(int lineWithStmtToBeReturned, CompilationUnit cu) {
+		VariableDeclarationExpr variableDeclarationExpr = RefactoringHelper
+				.getVariableDeclarationExprByLineNumber(lineWithStmtToBeReturned, cu);
+		if (variableDeclarationExpr.getVariables().size() > 1) {
+			throw new UnsupportedOperationException(
+					"Refactoring not yet supported for multiple variables declared at the same line.");
+		}
+
+		return variableDeclarationExpr.getVariable(0);
+	}
+
+	private List<ReturnStmt> findCorrespondingReturnStmts(String variableName, MethodDeclaration method) {
+		List<ReturnStmt> result = new LinkedList<>();
+		for (ReturnStmt returnStmt : method.findAll(ReturnStmt.class)) {
+			Optional<Expression> returnExpr = returnStmt.getExpression();
+
+			if (returnExpr.isPresent() && returnExpr.get().toString().equals(variableName)) {
+				result.add(returnStmt);
+			}
+		}
+
+		return result;
+	}
+
+}

--- a/src/main/java/de/refactoringbot/services/sonarqube/SonarQubeObjectTranslator.java
+++ b/src/main/java/de/refactoringbot/services/sonarqube/SonarQubeObjectTranslator.java
@@ -104,6 +104,10 @@ public class SonarQubeObjectTranslator {
 				botIssue.setRefactorString(getParameterName(issue));
 				botIssues.add(botIssue);
 				break;
+			case "squid:S1488":
+				botIssue.setRefactoringOperation(RefactoringOperations.IMMEDIATELY_RETURN_EXPRESSION);
+				botIssues.add(botIssue);
+				break;
 			default:
 				botIssue.setRefactoringOperation(RefactoringOperations.UNKNOWN);
 				break;

--- a/src/test/java/de/refactoringbot/refactorings/ImmediatelyReturnExpressionTest.java
+++ b/src/test/java/de/refactoringbot/refactorings/ImmediatelyReturnExpressionTest.java
@@ -1,0 +1,144 @@
+package de.refactoringbot.refactorings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.refactoringbot.model.botissue.BotIssue;
+import de.refactoringbot.model.configuration.GitConfiguration;
+import de.refactoringbot.model.exceptions.BotRefactoringException;
+import de.refactoringbot.refactoring.supportedrefactorings.ImmediatelyReturnExpression;
+import de.refactoringbot.resources.immediatelyreturn.TestDataClassImmediatelyReturnExpression;
+
+public class ImmediatelyReturnExpressionTest extends AbstractRefactoringTests {
+
+	private static final Logger logger = LoggerFactory.getLogger(ImmediatelyReturnExpressionTest.class);
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testImmediatelyReturnResult() throws Exception {
+		// arrange
+		int lineOfResultAssignment = TestDataClassImmediatelyReturnExpression.getLineOfResultAssignment();
+
+		// act
+		File modifiedTempFile = performRefactoring(lineOfResultAssignment);
+
+		// assert
+		String lineContent = getStrippedContentFromFile(modifiedTempFile, lineOfResultAssignment);
+		assertThat(lineContent).isEqualTo("return 12 + 0;");
+	}
+
+	@Test
+	public void testImmediatelyReturnResultEmptyLines() throws Exception {
+		// arrange
+		int lineOfResultAssignment = TestDataClassImmediatelyReturnExpression
+				.getLineOfResultAssignmentWithCommentLineAfter();
+
+		// act
+		File modifiedTempFile = performRefactoring(lineOfResultAssignment);
+
+		// assert
+		String lineContent = getStrippedContentFromFile(modifiedTempFile, lineOfResultAssignment + 1);
+		assertThat(lineContent).isEqualTo("return 17 + 0;");
+	}
+
+	@Test
+	public void testImmediatelyReturnResultWithMultipleIndependentReturns() throws Exception {
+		// arrange
+		int lineOfResultAssignment = TestDataClassImmediatelyReturnExpression.getLineOfSecondResultAssignment();
+
+		// act
+		File modifiedTempFile = performRefactoring(lineOfResultAssignment);
+
+		// assert
+		String lineContent = getStrippedContentFromFile(modifiedTempFile, lineOfResultAssignment);
+		assertThat(lineContent).isEqualTo("return 28 + 0;");
+	}
+
+	@Test
+	public void testReturnVariableUsedMoreThanOnce() throws Exception {
+		exception.expect(BotRefactoringException.class);
+
+		// arrange
+		int lineOfResultAssignment = TestDataClassImmediatelyReturnExpression.getLineOfAssignmentUsedMoreThanOnce();
+
+		// act
+		performRefactoring(lineOfResultAssignment);
+	}
+
+	@Test
+	public void testReturnOfComplexAssignment() throws Exception {
+		// arrange
+		int lineOfResultAssignment = TestDataClassImmediatelyReturnExpression.getLineOfComplexResultAssignment();
+
+		// act
+		File modifiedTempFile = performRefactoring(lineOfResultAssignment);
+
+		// assert
+		String lineContent = getStrippedContentFromFile(modifiedTempFile, lineOfResultAssignment);
+		assertThat(lineContent).isEqualTo("return 42 + (dummyMethod() * a);");
+	}
+
+	@Test
+	public void testResultAssignmentSpanningMultipleLines() throws Exception {
+		// arrange
+		int lineOfResultAssignment = TestDataClassImmediatelyReturnExpression
+				.getLineOfResultAssignmentSpanningMultipleLines();
+
+		// act
+		File modifiedTempFile = performRefactoring(lineOfResultAssignment);
+
+		// assert
+		String lineContent = getStrippedContentFromFile(modifiedTempFile, lineOfResultAssignment);
+		assertThat(lineContent).isEqualTo(
+				"return 47 + dummyMethod() + dummyMethod() + dummyMethod() + dummyMethod() + dummyMethod() + dummyMethod() + dummyMethod() + dummyMethod() + dummyMethod() + dummyMethod();");
+	}
+
+	@Test
+	public void testResultAssignmentWithLineComment() throws Exception {
+		// arrange
+		int lineOfResultAssignment = TestDataClassImmediatelyReturnExpression
+				.getLineOfResultAssignmentWithLineComment();
+
+		// act
+		File modifiedTempFile = performRefactoring(lineOfResultAssignment);
+		
+		// assert
+		String lineContentComment = getStrippedContentFromFile(modifiedTempFile, lineOfResultAssignment);
+		String lineContentReturn = getStrippedContentFromFile(modifiedTempFile, lineOfResultAssignment + 1);
+		assertThat(lineContentComment).isEqualTo("// comment");
+		assertThat(lineContentReturn).isEqualTo("return 53;");
+	}
+
+	private File performRefactoring(int line) throws Exception {
+		File tempFile = createTempCopyOfTestResourcesFile(TestDataClassImmediatelyReturnExpression.class);
+		ImmediatelyReturnExpression refactoring = new ImmediatelyReturnExpression();
+
+		ArrayList<String> javaRoots = new ArrayList<>();
+		javaRoots.add(getAbsolutePathOfTestsFolder());
+		BotIssue issue = new BotIssue();
+		issue.setFilePath(tempFile.getName());
+		issue.setLine(line);
+		issue.setJavaRoots(javaRoots);
+		List<String> allJavaFiles = new ArrayList<>();
+		allJavaFiles.add(tempFile.getCanonicalPath());
+		issue.setAllJavaFiles(allJavaFiles);
+		GitConfiguration gitConfig = new GitConfiguration();
+		gitConfig.setRepoFolder(getAbsolutePathOfTempFolder());
+
+		String outputMessage = refactoring.performRefactoring(issue, gitConfig);
+		logger.info(outputMessage);
+
+		return tempFile;
+	}
+}

--- a/src/test/java/de/refactoringbot/resources/immediatelyreturn/TestDataClassImmediatelyReturnExpression.java
+++ b/src/test/java/de/refactoringbot/resources/immediatelyreturn/TestDataClassImmediatelyReturnExpression.java
@@ -1,0 +1,57 @@
+package de.refactoringbot.resources.immediatelyreturn;
+
+public class TestDataClassImmediatelyReturnExpression {
+
+	private static int a = 0;
+
+	public static int dummyMethod() {
+		return 0;
+	}
+
+	public static int getLineOfResultAssignment() {
+		int result = 12 + 0;
+		return result;
+	}
+
+	public static int getLineOfResultAssignmentWithCommentLineAfter() {
+		int result = 17 + 0;
+		// comment
+		return result;
+	}
+
+	public static int getLineOfSecondResultAssignment() {
+		int aDoubled = a * 2;
+		if (aDoubled != 0) {
+			return 0;
+		}
+
+		int result = 28 + 0;
+		return result;
+	}
+
+	public static int getLineOfAssignmentUsedMoreThanOnce() {
+		int result = 33 + 0;
+		if (Math.random() > 0) {
+			return result;
+		}
+
+		return result;
+	}
+
+	public static int getLineOfComplexResultAssignment() {
+		int result = 42 + (dummyMethod() * a);
+		return result;
+	}
+
+	public static int getLineOfResultAssignmentSpanningMultipleLines() {
+		int result = 47 + dummyMethod() + dummyMethod() + dummyMethod() + dummyMethod() + dummyMethod() + dummyMethod()
+				+ dummyMethod() + dummyMethod() + dummyMethod() + dummyMethod();
+		return result;
+	}
+
+	public static int getLineOfResultAssignmentWithLineComment() {
+		int result = 53; // comment
+		return result;
+	}
+
+}


### PR DESCRIPTION
Implemented a new refactoring.

- [Example of the code smell](https://sonarcloud.io/project/issues?id=Bot-Playground%3ABot-Playground&open=AWohD2oV9zLXaOU8A6KH&resolved=false&types=CODE_SMELL)
- [Example of a bot's PR](https://github.com/MarvinWyrich/Bot-Playground/pull/12/commits) (don't know why the indentation is not preserved)