### PR TITLE
Removed ability to do comment refactorings on PRs from others.

### DIFF
--- a/src/main/java/de/refactoringbot/api/main/ApiGrabber.java
+++ b/src/main/java/de/refactoringbot/api/main/ApiGrabber.java
@@ -19,11 +19,9 @@ import de.refactoringbot.model.configuration.GitConfigurationDTO;
 import de.refactoringbot.model.exceptions.GitHubAPIException;
 import de.refactoringbot.model.exceptions.GitLabAPIException;
 import de.refactoringbot.model.github.pullrequest.GithubCreateRequest;
-import de.refactoringbot.model.github.pullrequest.GithubPullRequest;
 import de.refactoringbot.model.github.pullrequest.GithubPullRequests;
 import de.refactoringbot.model.github.repository.GithubRepository;
 import de.refactoringbot.model.gitlab.pullrequest.GitLabCreateRequest;
-import de.refactoringbot.model.gitlab.pullrequest.GitLabPullRequest;
 import de.refactoringbot.model.gitlab.pullrequest.GitLabPullRequests;
 import de.refactoringbot.model.gitlab.repository.GitLabRepository;
 import de.refactoringbot.model.output.botpullrequest.BotPullRequest;
@@ -110,38 +108,6 @@ public class ApiGrabber {
 		case gitlab:
 			gitlabGrabber.respondToUser(gitConfig, request.getRequestNumber(), comment.getDiscussionID(),
 					comment.getCommentID(), gitlabTranslator.getReplyComment(null));
-			break;
-		}
-	}
-
-	/**
-	 * This method creates a pull request of a filehoster.
-	 * 
-	 * @param request
-	 * @param gitConfig
-	 * @throws Exception
-	 */
-	public void makeCreateRequest(BotPullRequest request, BotPullRequestComment comment, GitConfiguration gitConfig,
-			String botBranchName) throws Exception {
-		// Pick filehoster
-		switch (gitConfig.getRepoService()) {
-		case github:
-			// Create PR Object
-			GithubCreateRequest createRequest = githubTranslator.makeCreateRequest(request, gitConfig, botBranchName);
-			// Create PR on filehoster
-			GithubPullRequest newGithubRequest = githubGrabber.createRequest(createRequest, gitConfig);
-			githubGrabber.responseToBotComment(
-					githubTranslator.createReplyComment(comment, newGithubRequest.getHtmlUrl()), gitConfig,
-					request.getRequestNumber());
-			break;
-		case gitlab:
-			// Create PR Object
-			GitLabCreateRequest gitlabCreateRequest = gitlabTranslator.makeCreateRequest(request, gitConfig,
-					botBranchName);
-			// Create PR on filehoster
-			GitLabPullRequest newGitLabRequest = gitlabGrabber.createRequest(gitlabCreateRequest, gitConfig);
-			gitlabGrabber.respondToUser(gitConfig, request.getRequestNumber(), comment.getDiscussionID(),
-					comment.getCommentID(), gitlabTranslator.getReplyComment(newGitLabRequest.getWebUrl()));
 			break;
 		}
 	}

--- a/src/main/java/de/refactoringbot/api/sonarqube/SonarQubeDataGrabber.java
+++ b/src/main/java/de/refactoringbot/api/sonarqube/SonarQubeDataGrabber.java
@@ -49,7 +49,7 @@ public class SonarQubeDataGrabber {
 			// Build URI
 			UriComponentsBuilder apiUriBuilder = createUriBuilder(gitConfig.getAnalysisServiceApiLink(), "/issues/search");
 
-			apiUriBuilder.queryParam("componentRoots", gitConfig.getAnalysisServiceProjectKey());
+			apiUriBuilder.queryParam("componentKeys", gitConfig.getAnalysisServiceProjectKey());
 			apiUriBuilder.queryParam("statuses", "OPEN,REOPENED");
 			apiUriBuilder.queryParam("ps", 500);
 			apiUriBuilder.queryParam("p", page);
@@ -75,7 +75,6 @@ public class SonarQubeDataGrabber {
 				break;
 
 			}
-
 		}
 
 		return issues;

--- a/src/main/java/de/refactoringbot/refactoring/supportedrefactorings/AddOverrideAnnotation.java
+++ b/src/main/java/de/refactoringbot/refactoring/supportedrefactorings/AddOverrideAnnotation.java
@@ -50,7 +50,7 @@ public class AddOverrideAnnotation implements RefactoringImpl {
 		out.close();
 
 		// Return commit message
-		return "Added override annotation to method " + methodDeclarationToModify.getNameAsString();
+		return "Added override annotation to method '" + methodDeclarationToModify.getNameAsString() + "'";
 	}
 
 	/**

--- a/src/main/java/de/refactoringbot/refactoring/supportedrefactorings/RenameMethod.java
+++ b/src/main/java/de/refactoringbot/refactoring/supportedrefactorings/RenameMethod.java
@@ -64,7 +64,7 @@ public class RenameMethod implements RefactoringImpl {
 		renameRelatedMethodDeclarationsAndMethodCalls(javaFilesRelevantForRefactoring, newMethodName);
 
 		String oldMethodName = targetMethod.getNameAsString();
-		return "Renamed method '" + oldMethodName + "' to '" + newMethodName + "'.";
+		return "Renamed method '" + oldMethodName + "' to '" + newMethodName + "'";
 	}
 
 	/**

--- a/src/main/java/de/refactoringbot/services/github/GithubObjectTranslator.java
+++ b/src/main/java/de/refactoringbot/services/github/GithubObjectTranslator.java
@@ -41,7 +41,7 @@ public class GithubObjectTranslator {
 	private final GithubDataGrabber grabber;
 	private final ModelMapper modelMapper;
 	private final GitService gitService;
-	private static final String PULL_REQUEST_DESCRIPTION = "Hi, I'm a refactoring bot. I found and fixed some code smells for you. \n\n You can instruct me to perform changes on this pull request by creating line specific (review) comments inside the 'Files changed' tab of this pull request. Use the english language to give me instructions and do not forget to tag me (using @) inside the comment to let me know that you are talking to me.";
+	private static final String PULL_REQUEST_DESCRIPTION = "Hi, I'm a refactoring bot. I found and fixed some code smells for you. \n\n You can instruct me to perform changes on this pull request by creating line specific comments inside the 'Files changed' tab of this pull request. Use the english language to give me instructions and do not forget to tag me (using @) inside the comment to let me know that you are talking to me.";
 
 	@Autowired
 	public GithubObjectTranslator(GithubDataGrabber grabber, ModelMapper modelMapper, GitService gitService) {
@@ -168,27 +168,6 @@ public class GithubObjectTranslator {
 
 	/**
 	 * This method creates an object that can be used to create a Pull-Request on
-	 * GitHub after a request comment refactoring.
-	 * 
-	 * @param gitConfig
-	 * @return createRequest
-	 */
-	public GithubCreateRequest makeCreateRequest(BotPullRequest refactoredRequest, GitConfiguration gitConfig,
-			String botBranchName) {
-		GithubCreateRequest createRequest = new GithubCreateRequest();
-
-		// Fill object with data
-		createRequest.setTitle("Bot Pull-Request Refactoring for PullRequest #" + refactoredRequest.getRequestNumber());
-		createRequest.setBody(PULL_REQUEST_DESCRIPTION);
-		createRequest.setHead(gitConfig.getBotName() + ":" + botBranchName);
-		createRequest.setBase(refactoredRequest.getBranchName());
-		createRequest.setMaintainer_can_modify(true);
-
-		return createRequest;
-	}
-
-	/**
-	 * This method creates an object that can be used to create a Pull-Request on
 	 * GitHub after a analysis service refactoring.
 	 * 
 	 * @param gitConfig
@@ -200,7 +179,7 @@ public class GithubObjectTranslator {
 		GithubCreateRequest createRequest = new GithubCreateRequest();
 
 		// Fill object with data
-		createRequest.setTitle("Bot Pull-Request Refactoring with '" + gitConfig.getAnalysisService() + "'");
+		createRequest.setTitle(issue.getCommitMessage());
 		createRequest.setBody(PULL_REQUEST_DESCRIPTION);
 		createRequest.setHead(gitConfig.getBotName() + ":" + newBranch);
 		createRequest.setBase("master");

--- a/src/main/java/de/refactoringbot/services/gitlab/GitlabObjectTranslator.java
+++ b/src/main/java/de/refactoringbot/services/gitlab/GitlabObjectTranslator.java
@@ -40,7 +40,7 @@ public class GitlabObjectTranslator {
 
 	private final GitlabDataGrabber grabber;
 	private final ModelMapper modelMapper;
-	private static final String PULL_REQUEST_DESCRIPTION = "Hi, I'm a refactoring bot. I found and fixed some code smells for you. \n\n You can instruct me to perform changes on this merge request by creating line specific (review) comments inside the 'Changes' tab of this merge request. Use the english language to give me instructions and do not forget to tag me (using @) inside the comment to let me know that you are talking to me.";
+	private static final String PULL_REQUEST_DESCRIPTION = "Hi, I'm a refactoring bot. I found and fixed some code smells for you. \n\n You can instruct me to perform changes on this merge request by creating line specific comments inside the 'Changes' tab of this merge request. Use the english language to give me instructions and do not forget to tag me (using @) inside the comment to let me know that you are talking to me.";
 
 	@Autowired
 	public GitlabObjectTranslator(GitlabDataGrabber grabber, ModelMapper modelMapper) {
@@ -167,31 +167,6 @@ public class GitlabObjectTranslator {
 		}
 
 		return translatedComments;
-	}
-
-	/**
-	 * This method creates an object that can be used to create a Pull-Request on
-	 * GitLab after a comment refactoring.
-	 * 
-	 * @param request
-	 * @param gitConfig
-	 * @param botBranchName
-	 * @return createRequest
-	 */
-	public GitLabCreateRequest makeCreateRequest(BotPullRequest refactoredRequest, GitConfiguration gitConfig,
-			String botBranchName) {
-		GitLabCreateRequest createRequest = new GitLabCreateRequest();
-
-		// Fill object with data
-		createRequest
-				.setTitle("Bot Merge-Request Refactoring for Merge-Request #" + refactoredRequest.getRequestNumber());
-		createRequest.setDescription(PULL_REQUEST_DESCRIPTION);
-		createRequest.setSource_branch(botBranchName);
-		createRequest.setTarget_branch(refactoredRequest.getBranchName());
-		createRequest.setAllow_collaboration(true);
-		createRequest.setTarget_project_id(getProjectId(gitConfig.getRepoApiLink()));
-
-		return createRequest;
 	}
 
 	/**

--- a/src/main/java/de/refactoringbot/services/main/RefactoringService.java
+++ b/src/main/java/de/refactoringbot/services/main/RefactoringService.java
@@ -101,7 +101,7 @@ public class RefactoringService {
 
 		// Return all refactored issues
 		if (isCommentRefactoring) {
-			return processComments(config, allRequests, amountOfBotRequests);
+			return processComments(config, allRequests);
 		} else {
 			return processAnalysisIssues(config, amountOfBotRequests);
 		}
@@ -163,11 +163,9 @@ public class RefactoringService {
 	 * 
 	 * @param config
 	 * @param allRequests
-	 * @param amountOfBotRequests
 	 * @return response
 	 */
-	private ResponseEntity<?> processComments(GitConfiguration config, BotPullRequests allRequests,
-			int amountBotRequests) {
+	private ResponseEntity<?> processComments(GitConfiguration config, BotPullRequests allRequests) {
 		List<RefactoredIssue> allRefactoredIssues = new ArrayList<>();
 
 		for (BotPullRequest request : allRequests.getAllPullRequests()) {

--- a/src/main/java/de/refactoringbot/services/scheduling/SchedulingService.java
+++ b/src/main/java/de/refactoringbot/services/scheduling/SchedulingService.java
@@ -37,7 +37,7 @@ public class SchedulingService {
 	 * This method performs a scheduled refactoring on all configurations with a
 	 * delay of 1 minute. It only performs refactorings with comments.
 	 */
-	@Scheduled(fixedDelay = 60000)
+	@Scheduled(fixedDelayString = "${scheduling.delayInMS:10000}")
 	public void performCommentRefactorings() {
 		
 		if(!isSchedulingEnabled) {

--- a/src/main/resources/application_example.yml
+++ b/src/main/resources/application_example.yml
@@ -24,3 +24,4 @@ bot:
 ---
 scheduling:
   enable: true
+  delayInMS: 10000


### PR DESCRIPTION
**Changes:**

- Bot can't refactor comments from PRs that do not belong to him (fixes: https://github.com/Refactoring-Bot/Refactoring-Bot/issues/49)
- Names of PRs created by the bot have the same name as the commit message
- If the maximal amount of open Bot-PRs is reached, a error message is shown in swagger (fixes: https://github.com/Refactoring-Bot/Refactoring-Bot/issues/58)
- Scheduling delay can now be set inside the yml file instead of the scheduling class