### PR TITLE
Implemented integration tests for sonar and wit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk9
+  - oraclejdk12
 addons:
   sonarcloud:
     organization: "refactoring-bot"

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.6.RELEASE</version>
+		<version>2.1.6.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,60 +74,60 @@
 			<scope>runtime</scope>
 		</dependency>
 
-		<!-- Für PATCH-Requests -->
+		<!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 		</dependency>
 
-		<!-- JavaParser dependencies -->
+		<!-- https://mvnrepository.com/artifact/com.github.javaparser/javaparser-symbol-solver-core -->
 		<dependency>
 			<groupId>com.github.javaparser</groupId>
 			<artifactId>javaparser-symbol-solver-core</artifactId>
 			<version>3.13.4</version>
 		</dependency>
 
-		<!-- Apache-Commons-IO -->
+		<!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.6</version>
 		</dependency>
 
-		<!-- Apache-Commons-Lang -->
+		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
 
-		<!-- Antlr -->
+		<!-- https://mvnrepository.com/artifact/org.antlr/antlr4-runtime -->
 		<dependency>
 			<groupId>org.antlr</groupId>
 			<artifactId>antlr4-runtime</artifactId>
 			<version>4.7.1</version>
 		</dependency>
 
-		<!-- JAXB dependency -->
+		<!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
 		<dependency>
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
 		</dependency>
 
-		<!-- Sonar-Source-Plugin -->
+		<!-- https://mvnrepository.com/artifact/org.sonarsource.scanner.maven/sonar-maven-plugin -->
 		<dependency>
 			<groupId>org.sonarsource.scanner.maven</groupId>
 			<artifactId>sonar-maven-plugin</artifactId>
 			<version>3.2</version>
 		</dependency>
 
-		<!-- model mapper -->
+		<!-- https://mvnrepository.com/artifact/org.modelmapper/modelmapper -->
 		<dependency>
 			<groupId>org.modelmapper</groupId>
 			<artifactId>modelmapper</artifactId>
 			<version>2.3.2</version>
 		</dependency>
-	</dependencies>
 
+	</dependencies>
 	<build>
 		<plugins>
 			<plugin>
@@ -146,7 +146,46 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+		
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<skipTests>true</skipTests> <!-- skip default-test execution -->
+				</configuration>
+				<executions>
+					<execution>
+						<id>unit-tests</id>
+						<phase>test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<skipTests>false</skipTests>
+							<includes>
+								<include>**/*Test.java</include>
+							</includes>
+						</configuration>
+					</execution>
+					<execution>
+						<id>integration-tests</id>
+						<phase>integration-test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<skipTests>false</skipTests>
+							<includes>
+								<include>**/*IT.*</include>
+								<include>**/*Tests.*</include>
+							</includes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			
 		</plugins>
+		
 	</build>
 
 

--- a/src/main/java/de/refactoringbot/api/main/ApiGrabber.java
+++ b/src/main/java/de/refactoringbot/api/main/ApiGrabber.java
@@ -14,10 +14,12 @@ import de.refactoringbot.api.github.GithubDataGrabber;
 import de.refactoringbot.api.gitlab.GitlabDataGrabber;
 import de.refactoringbot.api.sonarqube.SonarQubeDataGrabber;
 import de.refactoringbot.model.botissue.BotIssue;
+import de.refactoringbot.model.configuration.AnalysisProvider;
 import de.refactoringbot.model.configuration.GitConfiguration;
 import de.refactoringbot.model.configuration.GitConfigurationDTO;
 import de.refactoringbot.model.exceptions.GitHubAPIException;
 import de.refactoringbot.model.exceptions.GitLabAPIException;
+import de.refactoringbot.model.exceptions.SonarQubeAPIException;
 import de.refactoringbot.model.github.pullrequest.GithubCreateRequest;
 import de.refactoringbot.model.github.pullrequest.GithubPullRequests;
 import de.refactoringbot.model.github.repository.GithubRepository;
@@ -315,19 +317,19 @@ public class ApiGrabber {
 	 * 
 	 * @param analysisService
 	 * @param analysisServiceProjectKey
+	 * 
+	 * @throws SonarQubeAPIException
+	 * @throws URISyntaxException 
 	 */
-	private void checkAnalysisService(GitConfigurationDTO configuration) throws Exception {
+	private void checkAnalysisService(GitConfigurationDTO configuration) throws SonarQubeAPIException, URISyntaxException {
 		// Check if input exists
 		if (configuration.getAnalysisService() == null || configuration.getAnalysisServiceProjectKey() == null
 				|| configuration.getAnalysisServiceApiLink() == null) {
 			return;
 		}
 		// Pick service
-		switch (configuration.getAnalysisService()) {
-		case sonarqube:
+		if (configuration.getAnalysisService().equals(AnalysisProvider.sonarqube)) {
 			sonarQubeGrabber.checkSonarData(configuration);
-			break;
 		}
-
 	}
 }

--- a/src/main/java/de/refactoringbot/api/sonarqube/SonarQubeDataGrabber.java
+++ b/src/main/java/de/refactoringbot/api/sonarqube/SonarQubeDataGrabber.java
@@ -68,10 +68,10 @@ public class SonarQubeDataGrabber {
 
 			try {
 				// Send request
-				SonarQubeIssues response = rest.exchange(sonarQubeURI, HttpMethod.GET, entity, SonarQubeIssues.class)
+				SonarQubeIssues issueBucket = rest.exchange(sonarQubeURI, HttpMethod.GET, entity, SonarQubeIssues.class)
 						.getBody();
-				issues.add(response);
-				if (response.getIssues().size() < maxNumberOfIssuesInASingleCall) {
+				issues.add(issueBucket);
+				if (issueBucket.getIssues().size() < maxNumberOfIssuesInASingleCall) {
 					break;
 				}
 			} catch (RestClientException e) {

--- a/src/main/java/de/refactoringbot/api/sonarqube/SonarQubeDataGrabber.java
+++ b/src/main/java/de/refactoringbot/api/sonarqube/SonarQubeDataGrabber.java
@@ -39,19 +39,23 @@ public class SonarQubeDataGrabber {
 	 * @param sonarQubeProjectKey
 	 * @return allIssues
 	 * @throws SonarQubeAPIException
+	 * @throws URISyntaxException
 	 */
-	public List<SonarQubeIssues> getIssues(GitConfiguration gitConfig) throws SonarQubeAPIException, URISyntaxException {
-		int page = 1;
-
+	public List<SonarQubeIssues> getIssues(GitConfiguration gitConfig)
+			throws SonarQubeAPIException, URISyntaxException {
+		final int maxPage = 4; // results in a maximum of 4 * 500 = 2000 issues
+		final int maxNumberOfIssuesInASingleCall = 500; // maximum allowed by the sonarQube API
+		
 		List<SonarQubeIssues> issues = new ArrayList<>();
-
-		while (page < 500) {
+		
+		for (int page = 1; page < maxPage; page++) {
 			// Build URI
-			UriComponentsBuilder apiUriBuilder = createUriBuilder(gitConfig.getAnalysisServiceApiLink(), "/issues/search");
+			UriComponentsBuilder apiUriBuilder = createUriBuilder(gitConfig.getAnalysisServiceApiLink(),
+					"/issues/search");
 
 			apiUriBuilder.queryParam("componentKeys", gitConfig.getAnalysisServiceProjectKey());
 			apiUriBuilder.queryParam("statuses", "OPEN,REOPENED");
-			apiUriBuilder.queryParam("ps", 500);
+			apiUriBuilder.queryParam("ps", maxNumberOfIssuesInASingleCall);
 			apiUriBuilder.queryParam("p", page);
 
 			URI sonarQubeURI = apiUriBuilder.build().encode().toUri();
@@ -64,16 +68,18 @@ public class SonarQubeDataGrabber {
 
 			try {
 				// Send request
-				issues.add(rest.exchange(sonarQubeURI, HttpMethod.GET, entity, SonarQubeIssues.class).getBody());
-				page++;
+				SonarQubeIssues response = rest.exchange(sonarQubeURI, HttpMethod.GET, entity, SonarQubeIssues.class)
+						.getBody();
+				issues.add(response);
+				if (response.getIssues().size() < maxNumberOfIssuesInASingleCall) {
+					break;
+				}
 			} catch (RestClientException e) {
 				if (page == 1) {
 					logger.error(e.getMessage(), e);
 					throw new SonarQubeAPIException("Could not access SonarQube API!", e);
 				}
-
 				break;
-
 			}
 		}
 
@@ -87,13 +93,21 @@ public class SonarQubeDataGrabber {
 	 * 
 	 * @param analysisServiceProjectKey
 	 * @throws SonarQubeAPIException
+	 * @throws URISyntaxException
+	 * 
+	 * @return true if configured analysis service is valid, throws exception
+	 *         otherwise
 	 */
-	public void checkSonarData(GitConfigurationDTO configuration) throws SonarQubeAPIException, URISyntaxException {
+	public boolean checkSonarData(GitConfigurationDTO configuration) throws SonarQubeAPIException, URISyntaxException {
 		// Build URI
-		UriComponentsBuilder apiUriBuilder = createUriBuilder(configuration.getAnalysisServiceApiLink(), "/components/show");
-
+		UriComponentsBuilder apiUriBuilder = null;
+		try {
+			apiUriBuilder = createUriBuilder(configuration.getAnalysisServiceApiLink(), "/components/show");
+		} catch (URISyntaxException e) {
+			throw new URISyntaxException(
+					"Error checking analysis service data. Could not create URI from given API link! ", e.getMessage());
+		}
 		apiUriBuilder.queryParam("component", configuration.getAnalysisServiceProjectKey());
-
 		URI sonarQubeURI = apiUriBuilder.build().encode().toUri();
 
 		RestTemplate rest = new RestTemplate();
@@ -103,12 +117,13 @@ public class SonarQubeDataGrabber {
 		HttpEntity<String> entity = new HttpEntity<>("parameters", headers);
 
 		try {
-			// Send request
 			rest.exchange(sonarQubeURI, HttpMethod.GET, entity, SonarQubeIssues.class).getBody();
 		} catch (RestClientException e) {
-			logger.error(e.getMessage(), e);
-			throw new SonarQubeAPIException("Project with given project key does not exist on SonarQube!", e);
+			throw new SonarQubeAPIException(
+					"Error checking analysis service data. Project with given project key might not exist.");
 		}
+
+		return true;
 	}
 
 	/**
@@ -124,15 +139,10 @@ public class SonarQubeDataGrabber {
 	private UriComponentsBuilder createUriBuilder(String link, String apiEntryPoint) throws URISyntaxException {
 		URI result = null;
 		UriComponentsBuilder apiUriBuilder = null;
-		try {
-			result = new URI(link);
-			apiUriBuilder = UriComponentsBuilder.newInstance().scheme(result.getScheme()).host(result.getHost()).port(result.getPort())
-					.path(result.getPath() + apiEntryPoint);
-			return apiUriBuilder;
-		} catch (URISyntaxException u) {
-			logger.error(u.getMessage(), u);
-			throw new URISyntaxException("Could not create URI from given API link!", u.getMessage());
-		}
+		result = new URI(link);
+		apiUriBuilder = UriComponentsBuilder.newInstance().scheme(result.getScheme()).host(result.getHost())
+				.port(result.getPort()).path(result.getPath() + apiEntryPoint);
+		return apiUriBuilder;
 	}
 
 }

--- a/src/main/java/de/refactoringbot/api/wit/WitDataGrabber.java
+++ b/src/main/java/de/refactoringbot/api/wit/WitDataGrabber.java
@@ -24,8 +24,12 @@ import de.refactoringbot.model.wit.WitObject;
 @Component
 public class WitDataGrabber {
 
+	private BotConfiguration botConfig;
+	
 	@Autowired
-	BotConfiguration botConfig;
+	public WitDataGrabber(BotConfiguration botConfig) {
+		this.botConfig = botConfig;
+	}
 
 	private static final String USER_AGENT = "Mozilla/5.0";
 

--- a/src/main/java/de/refactoringbot/services/main/RefactoringService.java
+++ b/src/main/java/de/refactoringbot/services/main/RefactoringService.java
@@ -19,7 +19,12 @@ import de.refactoringbot.configuration.BotConfiguration;
 import de.refactoringbot.model.botissue.BotIssue;
 import de.refactoringbot.model.configuration.ConfigurationRepository;
 import de.refactoringbot.model.configuration.GitConfiguration;
-import de.refactoringbot.model.exceptions.*;
+import de.refactoringbot.model.exceptions.BotRefactoringException;
+import de.refactoringbot.model.exceptions.DatabaseConnectionException;
+import de.refactoringbot.model.exceptions.GitHubAPIException;
+import de.refactoringbot.model.exceptions.GitLabAPIException;
+import de.refactoringbot.model.exceptions.GitWorkflowException;
+import de.refactoringbot.model.exceptions.ReviewCommentUnclearException;
 import de.refactoringbot.model.output.botpullrequest.BotPullRequest;
 import de.refactoringbot.model.output.botpullrequest.BotPullRequests;
 import de.refactoringbot.model.output.botpullrequestcomment.BotPullRequestComment;
@@ -180,7 +185,7 @@ public class RefactoringService {
 						if (!grammarService.checkComment(comment.getCommentBody(), config)) {
 							// Try to parse with wit.ai
 							try {
-								botIssue = witService.createBotIssue(config, comment);
+								botIssue = witService.createBotIssue(comment);
 								logger.info("Comment translated with 'wit.ai': " + comment.getCommentBody());
 							} catch (IOException e) {
 								logger.error(e.getMessage(), e);

--- a/src/main/java/de/refactoringbot/services/main/RefactoringService.java
+++ b/src/main/java/de/refactoringbot/services/main/RefactoringService.java
@@ -25,6 +25,7 @@ import de.refactoringbot.model.exceptions.GitHubAPIException;
 import de.refactoringbot.model.exceptions.GitLabAPIException;
 import de.refactoringbot.model.exceptions.GitWorkflowException;
 import de.refactoringbot.model.exceptions.ReviewCommentUnclearException;
+import de.refactoringbot.model.exceptions.WitAPIException;
 import de.refactoringbot.model.output.botpullrequest.BotPullRequest;
 import de.refactoringbot.model.output.botpullrequest.BotPullRequests;
 import de.refactoringbot.model.output.botpullrequestcomment.BotPullRequestComment;
@@ -186,14 +187,8 @@ public class RefactoringService {
 							// Try to parse with wit.ai
 							try {
 								botIssue = witService.createBotIssue(comment);
-								logger.info("Comment translated with 'wit.ai': " + comment.getCommentBody());
-							} catch (IOException e) {
-								logger.error(e.getMessage(), e);
-								botIssue = createBotIssueFromInvalidComment(comment, e.getMessage());
-								allRefactoredIssues
-										.add(processFailedRefactoring(config, comment, request, botIssue, true));
-								return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-							} catch (ReviewCommentUnclearException e) {
+								logger.info("Comment translated with 'wit.ai': {}", comment.getCommentBody());
+							} catch (ReviewCommentUnclearException | WitAPIException e) {
 								logger.warn("Comment translation with 'wit.ai' failed! Comment: "
 										+ comment.getCommentBody());
 								botIssue = createBotIssueFromInvalidComment(comment, e.getMessage());
@@ -206,7 +201,7 @@ public class RefactoringService {
 							try {
 								// If ANTLR can parse -> create Issue
 								botIssue = grammarService.createIssueFromComment(comment, config);
-								logger.info("Comment translated with 'ANTLR': " + comment.getCommentBody());
+								logger.info("Comment translated with 'ANTLR': {}", comment.getCommentBody());
 							} catch (Exception g) {
 								logger.error(g.getMessage(), g);
 								// If refactoring failed

--- a/src/main/java/de/refactoringbot/services/wit/WitService.java
+++ b/src/main/java/de/refactoringbot/services/wit/WitService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 
 import de.refactoringbot.api.wit.WitDataGrabber;
 import de.refactoringbot.model.botissue.BotIssue;
-import de.refactoringbot.model.configuration.GitConfiguration;
 import de.refactoringbot.model.exceptions.ReviewCommentUnclearException;
 import de.refactoringbot.model.exceptions.WitAPIException;
 import de.refactoringbot.model.output.botpullrequestcomment.BotPullRequestComment;
@@ -41,12 +40,11 @@ public class WitService {
 	 * This method creates a BotIssue from a message with the help of the wit.ai
 	 * service.
 	 * 
-	 * @param gitConfig
 	 * @param comment
 	 * @return botIssue
 	 * @throws ReviewCommentUnclearException
 	 */
-	public BotIssue createBotIssue(GitConfiguration gitConfig, BotPullRequestComment comment)
+	public BotIssue createBotIssue(BotPullRequestComment comment)
 			throws ReviewCommentUnclearException, IOException {
 		try {
 			BotIssue issue = new BotIssue();
@@ -58,7 +56,7 @@ public class WitService {
 			mapCommentBodyToIssue(issue, comment.getCommentBody());
 			return issue;
 		} catch (WitAPIException | ReviewCommentUnclearException e) {
-			logger.error(e.getMessage(), e);
+			logger.error(e.getMessage());
 			throw new ReviewCommentUnclearException(e.getMessage());
 		}
 	}

--- a/src/test/java/de/refactoringbot/api/sonarqube/SonarQubeDataGrabberIT.java
+++ b/src/test/java/de/refactoringbot/api/sonarqube/SonarQubeDataGrabberIT.java
@@ -1,10 +1,12 @@
 package de.refactoringbot.api.sonarqube;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.net.URISyntaxException;
 import java.util.List;
 
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -34,6 +36,15 @@ public class SonarQubeDataGrabberIT {
 	@Rule
 	public final ExpectedException exception = ExpectedException.none();
 
+	@BeforeClass
+	public static void beforeClass() {
+		/*
+		 * This test gets skipped if it is not executed on the build server. To
+		 * successfully run it on a local machine, this method must not be executed.
+		 */
+		assumeThat(System.getenv("TRAVIS")).isNotNull();
+	}
+	
 	@Test
 	public void testCheckSonarData() throws Exception {
 		// arrange

--- a/src/test/java/de/refactoringbot/api/sonarqube/SonarQubeDataGrabberIT.java
+++ b/src/test/java/de/refactoringbot/api/sonarqube/SonarQubeDataGrabberIT.java
@@ -1,0 +1,96 @@
+package de.refactoringbot.api.sonarqube;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import de.refactoringbot.model.configuration.AnalysisProvider;
+import de.refactoringbot.model.configuration.GitConfiguration;
+import de.refactoringbot.model.configuration.GitConfigurationDTO;
+import de.refactoringbot.model.exceptions.SonarQubeAPIException;
+import de.refactoringbot.model.sonarqube.SonarQubeIssues;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { SonarQubeDataGrabber.class })
+@EnableConfigurationProperties
+public class SonarQubeDataGrabberIT {
+
+	@Autowired
+	SonarQubeDataGrabber sonarQubeDataGrabber;
+
+	private static final String API_LINK = "https://sonarcloud.io/api";
+	private static final String PROJECT_KEY = "Bot-Playground:Bot-Playground";
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testCheckSonarData() throws Exception {
+		// arrange
+		GitConfigurationDTO gitConfig = new GitConfigurationDTO();
+		gitConfig.setAnalysisService(AnalysisProvider.sonarqube);
+		gitConfig.setAnalysisServiceApiLink(API_LINK);
+		gitConfig.setAnalysisServiceProjectKey(PROJECT_KEY);
+
+		// act
+		boolean allChecksOkay = sonarQubeDataGrabber.checkSonarData(gitConfig);
+		
+		// assert
+		assertThat(allChecksOkay).isTrue();
+	}
+
+	@Test
+	public void testCheckSonarDataNotExistingProjectKey() throws Exception {
+		exception.expect(SonarQubeAPIException.class);
+		
+		// arrange
+		GitConfigurationDTO gitConfig = new GitConfigurationDTO();
+		gitConfig.setAnalysisService(AnalysisProvider.sonarqube);
+		gitConfig.setAnalysisServiceApiLink(API_LINK);
+		gitConfig.setAnalysisServiceProjectKey("should-not-exist");
+
+		// act
+		sonarQubeDataGrabber.checkSonarData(gitConfig);
+	}
+	
+	@Test
+	public void testCheckSonarDataWrongAPILink() throws Exception {
+		exception.expect(URISyntaxException.class);
+		
+		// arrange
+		GitConfigurationDTO gitConfig = new GitConfigurationDTO();
+		gitConfig.setAnalysisService(AnalysisProvider.sonarqube);
+		gitConfig.setAnalysisServiceApiLink("definitely not a valid URL");
+		gitConfig.setAnalysisServiceProjectKey(PROJECT_KEY);
+
+		// act
+		sonarQubeDataGrabber.checkSonarData(gitConfig);
+	}
+	
+	@Test
+	public void testGetIssues() throws Exception {
+		// arrange
+		GitConfiguration gitConfig = new GitConfiguration();
+		gitConfig.setAnalysisService(AnalysisProvider.sonarqube);
+		gitConfig.setAnalysisServiceApiLink(API_LINK);
+		gitConfig.setAnalysisServiceProjectKey(PROJECT_KEY);
+		
+		// act
+		List<SonarQubeIssues> issueBuckets = sonarQubeDataGrabber.getIssues(gitConfig);
+		
+		// assert
+		assertThat(issueBuckets).hasSize(1);
+		assertThat(issueBuckets.get(0).getIssues().size()).isBetween(3, 100);
+	}
+
+}

--- a/src/test/java/de/refactoringbot/services/wit/WitServiceIT.java
+++ b/src/test/java/de/refactoringbot/services/wit/WitServiceIT.java
@@ -33,7 +33,7 @@ import de.refactoringbot.refactoring.RefactoringOperations;
 public class WitServiceIT {
 
 	public final static String WIT_CLIENT_TOKEN_ENV_NAME = "WIT_CLIENT_TOKEN";
-	
+
 	private WitService witService;
 	@Mock
 	private WitDataGrabber witDataGrabber;
@@ -41,18 +41,23 @@ public class WitServiceIT {
 	private BotConfiguration botConfig;
 	@Autowired
 	DataAnonymizerService dataAnonymizer;
-	
+
 	@Rule
 	public final ExpectedException exception = ExpectedException.none();
 
 	@BeforeClass
 	public static void beforeClass() {
+		/*
+		 * This test gets skipped if it is not executed on the build server. To
+		 * successfully run it on a local machine, this method must not be executed and
+		 * a client token for wit API access must be provided in the mock.
+		 */
 		assumeThat(System.getenv("TRAVIS")).isNotNull();
 		assumeThat(System.getenv(WIT_CLIENT_TOKEN_ENV_NAME)).isNotNull();
 	}
 
 	@Before
-	public void init() {		
+	public void init() {
 		witDataGrabber = new WitDataGrabber(botConfig);
 		witService = new WitService(witDataGrabber, dataAnonymizer);
 		String tokenValue = System.getenv(WIT_CLIENT_TOKEN_ENV_NAME);
@@ -60,7 +65,7 @@ public class WitServiceIT {
 	}
 
 	@Test
-	public void testAddOverrideAnnotationComment() throws Exception {		
+	public void testAddOverrideAnnotationComment() throws Exception {
 		// arrange + act
 		BotIssue issue = createBotIssueForCommentBody("Hey @Bot, add an override annotation here, ok?");
 

--- a/src/test/java/de/refactoringbot/services/wit/WitServiceIT.java
+++ b/src/test/java/de/refactoringbot/services/wit/WitServiceIT.java
@@ -11,6 +11,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -31,13 +32,16 @@ import de.refactoringbot.refactoring.RefactoringOperations;
 @EnableConfigurationProperties
 public class WitServiceIT {
 
-	@Autowired
-	BotConfiguration botConfig;
-	@Autowired
-	WitService witService;
-
 	public final static String WIT_CLIENT_TOKEN_ENV_NAME = "WIT_CLIENT_TOKEN";
-
+	
+	private WitService witService;
+	@Mock
+	private WitDataGrabber witDataGrabber;
+	@Mock
+	private BotConfiguration botConfig;
+	@Autowired
+	DataAnonymizerService dataAnonymizer;
+	
 	@Rule
 	public final ExpectedException exception = ExpectedException.none();
 
@@ -48,14 +52,15 @@ public class WitServiceIT {
 	}
 
 	@Before
-	public void initMocks() {
+	public void init() {		
+		witDataGrabber = new WitDataGrabber(botConfig);
+		witService = new WitService(witDataGrabber, dataAnonymizer);
 		String tokenValue = System.getenv(WIT_CLIENT_TOKEN_ENV_NAME);
-		botConfig = Mockito.mock(BotConfiguration.class);
 		Mockito.when(botConfig.getWitClientToken()).thenReturn(tokenValue);
 	}
 
 	@Test
-	public void testAddOverrideAnnotationComment() throws Exception {
+	public void testAddOverrideAnnotationComment() throws Exception {		
 		// arrange + act
 		BotIssue issue = createBotIssueForCommentBody("Hey @Bot, add an override annotation here, ok?");
 

--- a/src/test/java/de/refactoringbot/services/wit/WitServiceIT.java
+++ b/src/test/java/de/refactoringbot/services/wit/WitServiceIT.java
@@ -3,8 +3,6 @@ package de.refactoringbot.services.wit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 
-import java.io.IOException;
-
 import org.assertj.core.api.SoftAssertions;
 import org.junit.Rule;
 import org.junit.Test;
@@ -19,6 +17,7 @@ import de.refactoringbot.api.wit.WitDataGrabber;
 import de.refactoringbot.configuration.BotConfiguration;
 import de.refactoringbot.model.botissue.BotIssue;
 import de.refactoringbot.model.exceptions.ReviewCommentUnclearException;
+import de.refactoringbot.model.exceptions.WitAPIException;
 import de.refactoringbot.model.output.botpullrequestcomment.BotPullRequestComment;
 import de.refactoringbot.refactoring.RefactoringOperations;
 
@@ -165,7 +164,7 @@ public class WitServiceIT {
 	}
 
 	private BotIssue createBotIssueForCommentBody(String commentBody)
-			throws ReviewCommentUnclearException, IOException {
+			throws ReviewCommentUnclearException, WitAPIException {
 		// arrange
 		BotPullRequestComment comment = new BotPullRequestComment();
 		comment.setCommentID(1);

--- a/src/test/java/de/refactoringbot/services/wit/WitServiceIT.java
+++ b/src/test/java/de/refactoringbot/services/wit/WitServiceIT.java
@@ -1,0 +1,178 @@
+package de.refactoringbot.services.wit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import de.refactoringbot.api.wit.WitDataGrabber;
+import de.refactoringbot.configuration.BotConfiguration;
+import de.refactoringbot.model.botissue.BotIssue;
+import de.refactoringbot.model.exceptions.ReviewCommentUnclearException;
+import de.refactoringbot.model.output.botpullrequestcomment.BotPullRequestComment;
+import de.refactoringbot.refactoring.RefactoringOperations;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { BotConfiguration.class, WitDataGrabber.class, DataAnonymizerService.class,
+		WitService.class })
+@EnableConfigurationProperties
+public class WitServiceIT {
+
+	@Autowired
+	BotConfiguration botConfig;
+	@Autowired
+	WitService witService;
+
+	@Rule
+	public final ExpectedException exception = ExpectedException.none();
+	
+	@Test
+	public void testAddOverrideAnnotationComment() throws Exception {
+		// arrange + act
+		BotIssue issue = createBotIssueForCommentBody("Hey @Bot, add an override annotation here, ok?");
+
+		// assert
+		assertNotNull(issue);
+		assertThat(issue.getRefactoringOperation()).isEqualTo(RefactoringOperations.ADD_OVERRIDE_ANNOTATION);
+	}
+
+	@Test
+	public void testAddOverrideAnnotationComment2() throws Exception {
+		// arrange + act
+		BotIssue issue = createBotIssueForCommentBody("@Bot please add annotation \"Override\" here");
+
+		// assert
+		assertNotNull(issue);
+		assertThat(issue.getRefactoringOperation()).isEqualTo(RefactoringOperations.ADD_OVERRIDE_ANNOTATION);
+	}
+
+	@Test
+	public void testAddOverrideAnnotationCommentUnclearAnnotation() throws Exception {
+		exception.expect(ReviewCommentUnclearException.class);
+		createBotIssueForCommentBody("Hey @Bot, add the missing annotation.");
+	}
+
+	@Test
+	public void testAddOverrideAnnotationCommentUnsupportedAnnotation() throws Exception {
+		exception.expect(ReviewCommentUnclearException.class);
+		createBotIssueForCommentBody("Hey @Bot, add annotation NotExistingOrUnsupportedOperation.");
+	}
+
+	@Test
+	public void testReorderModifierComment() throws Exception {
+		// arrange + act
+		BotIssue issue = createBotIssueForCommentBody("@Bot please reorder these modifiers");
+
+		// assert
+		assertNotNull(issue);
+		assertThat(issue.getRefactoringOperation()).isEqualTo(RefactoringOperations.REORDER_MODIFIER);
+	}
+	
+	@Test
+	public void testReorderModifierComment2() throws Exception {
+		// arrange + act
+		BotIssue issue = createBotIssueForCommentBody("@Bot please put the modifiers in an order that complies with the JLS.!");
+
+		// assert
+		assertNotNull(issue);
+		assertThat(issue.getRefactoringOperation()).isEqualTo(RefactoringOperations.REORDER_MODIFIER);
+	}
+	
+	@Test
+	public void testRenameMethodComment() throws Exception {
+		// arrange + act
+		BotIssue issue = createBotIssueForCommentBody("@Bot Please rename this method to getABC");
+
+		// assert
+		assertNotNull(issue);
+		SoftAssertions softAssertions = new SoftAssertions();
+		softAssertions.assertThat(issue.getRefactoringOperation()).isEqualTo(RefactoringOperations.RENAME_METHOD);
+		softAssertions.assertThat(issue.getRefactorString()).isEqualTo("getABC");
+		softAssertions.assertAll();
+	}
+
+	@Test
+	public void testRenameMethodComment2() throws Exception {
+		// arrange + act
+		BotIssue issue = createBotIssueForCommentBody("Could you rename this to \"doSomething\" @Bot?");
+
+		// assert
+		assertNotNull(issue);
+		SoftAssertions softAssertions = new SoftAssertions();
+		softAssertions.assertThat(issue.getRefactoringOperation()).isEqualTo(RefactoringOperations.RENAME_METHOD);
+		softAssertions.assertThat(issue.getRefactorString()).isEqualTo("doSomething");
+		softAssertions.assertAll();
+	}
+
+	@Test
+	public void testRenameMethodCommentUnclearNewName() throws Exception {
+		exception.expect(ReviewCommentUnclearException.class);
+		createBotIssueForCommentBody("@Bot please rename this method!");
+	}
+
+	@Test
+	public void testRenameMethodCommentUnclearNewName2() throws Exception {
+		exception.expect(ReviewCommentUnclearException.class);
+		createBotIssueForCommentBody("@Bot Rename this method, ok?");
+	}
+
+	@Test
+	public void testRenameMethodCommentUnclearNewName3() throws Exception {
+		exception.expect(ReviewCommentUnclearException.class);
+		createBotIssueForCommentBody("@Bot Could you rename this method please?");
+	}
+
+	@Test
+	public void testRemoveParameterComment() throws Exception {
+		// arrange + act
+		BotIssue issue = createBotIssueForCommentBody("@Bot could you remove parameter unusedParam?");
+
+		// assert
+		assertNotNull(issue);
+		SoftAssertions softAssertions = new SoftAssertions();
+		softAssertions.assertThat(issue.getRefactoringOperation()).isEqualTo(RefactoringOperations.REMOVE_PARAMETER);
+		softAssertions.assertThat(issue.getRefactorString()).isEqualTo("unusedParam");
+		softAssertions.assertAll();
+	}
+	
+	@Test
+	public void testRemoveParameterComment2() throws Exception {
+		// arrange + act
+		BotIssue issue = createBotIssueForCommentBody("@Bot, please remove this parameter: param");
+
+		// assert
+		assertNotNull(issue);
+		SoftAssertions softAssertions = new SoftAssertions();
+		softAssertions.assertThat(issue.getRefactoringOperation()).isEqualTo(RefactoringOperations.REMOVE_PARAMETER);
+		softAssertions.assertThat(issue.getRefactorString()).isEqualTo("param");
+		softAssertions.assertAll();
+	}
+	
+	@Test
+	public void testRemoveParamterUnclearParam() throws Exception {
+		exception.expect(ReviewCommentUnclearException.class);
+		createBotIssueForCommentBody("@Bot please remove the other unused parameter");
+	}
+
+	private BotIssue createBotIssueForCommentBody(String commentBody)
+			throws ReviewCommentUnclearException, IOException {
+		// arrange
+		BotPullRequestComment comment = new BotPullRequestComment();
+		comment.setCommentID(1);
+		comment.setCommentBody(commentBody);
+
+		// act
+		return witService.createBotIssue(comment);
+	}
+
+}


### PR DESCRIPTION
- Updated from `jdk9` to `jdk12` and spring boot from `2.0.6.RELEASE` to `2.1.6.RELEASE`
- Integration tests are named `*IT.java` and executed after the unit tests (and only if unit tests run successful)
- Added integration tests for sonarQube and wit.ai functionality. They run by default only on the build server, since the environment variables (such as access tokens) are stored there
- Fixed some code smells in the treated classes 